### PR TITLE
feat: Salesforce NPSP integration and integration test suite

### DIFF
--- a/Application/src/main/java/com/kenzie/appserver/controller/CampaignController.java
+++ b/Application/src/main/java/com/kenzie/appserver/controller/CampaignController.java
@@ -44,8 +44,10 @@ public class CampaignController {
     }
 
     @PutMapping("/{campaignId}")
-    public ResponseEntity<CampaignResponse> updateCampaign(@Valid @RequestBody CampaignUpdateRequest request) {
-        CampaignResponse response = campaignService.updateCampaign(request);
+    public ResponseEntity<CampaignResponse> updateCampaign(
+            @Valid @RequestBody CampaignUpdateRequest request,
+            Authentication authentication) {
+        CampaignResponse response = campaignService.updateCampaign(request, authentication.getName());
         return ResponseEntity.ok(response);
     }
 

--- a/Application/src/main/java/com/kenzie/appserver/salesforce/SalesforceService.java
+++ b/Application/src/main/java/com/kenzie/appserver/salesforce/SalesforceService.java
@@ -50,10 +50,12 @@ public class SalesforceService {
 
             String sfId = client.create("Campaign", fields);
 
-            // Store the SF ID back so donations can reference it
-            record.setSalesforceCampaignId(sfId);
-            campaignDao.save(record);
-            log.info("Campaign synced to Salesforce: local={} sf={}", record.getId(), sfId);
+            // Re-fetch before writing back to avoid overwriting concurrent updates (donations, status changes)
+            campaignDao.findById(record.getId()).ifPresentOrElse(latest -> {
+                latest.setSalesforceCampaignId(sfId);
+                campaignDao.save(latest);
+                log.info("Campaign synced to Salesforce: local={} sf={}", latest.getId(), sfId);
+            }, () -> log.warn("Skipping SF campaign ID persist; local campaign not found: {}", record.getId()));
 
         } catch (Exception e) {
             log.error("Failed to sync campaign {} to Salesforce: {}", record.getId(), e.getMessage());
@@ -74,6 +76,8 @@ public class SalesforceService {
 
             if (record.getSalesforceCampaignId() != null) {
                 fields.put("CampaignId", record.getSalesforceCampaignId());
+            } else {
+                log.warn("Donation Opportunity created without CampaignId — SF campaign not yet synced: local={}", record.getId());
             }
 
             String sfId = client.create("Opportunity", fields);

--- a/Application/src/main/java/com/kenzie/appserver/service/CampaignService.java
+++ b/Application/src/main/java/com/kenzie/appserver/service/CampaignService.java
@@ -59,11 +59,11 @@ public class CampaignService {
         return recordToResponse(record);
     }
 
-    public CampaignResponse updateCampaign(CampaignUpdateRequest request) {
+    public CampaignResponse updateCampaign(CampaignUpdateRequest request, String requestingUserId) {
         CampaignRecord record = campaignDao.findById(request.getId())
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Campaign not found"));
 
-        if (!record.getUser().getId().equals(request.getUser().getId())) {
+        if (!record.getUser().getId().equals(requestingUserId)) {
             throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Only the campaign creator can update this campaign");
         }
         if (CampaignStatus.CLOSED.name().equals(record.getStatus())) {

--- a/Application/src/test/java/com/kenzie/appserver/service/CampaignServiceTest.java
+++ b/Application/src/test/java/com/kenzie/appserver/service/CampaignServiceTest.java
@@ -266,10 +266,37 @@ class CampaignServiceTest {
         request.setDescription("Updated description");
         request.setGoalAmount(300000L);
 
-        CampaignResponse response = campaignService.updateCampaign(request);
+        CampaignResponse response = campaignService.updateCampaign(request, "user-1");
 
         assertEquals("Updated Name", response.getName());
         verify(cache).evict("camp-10");
+    }
+
+    @Test
+    void updateCampaign_notOwner_throwsForbidden() {
+        User owner = new User("user-1", "Stacey", "stacey@example.com");
+        CampaignRecord record = campaignRecord("camp-10b");
+        record.setUser(owner);
+
+        when(campaignDao.findById("camp-10b")).thenReturn(Optional.of(record));
+
+        CampaignUpdateRequest request = new CampaignUpdateRequest();
+        request.setId("camp-10b");
+        request.setName("Hijacked");
+        request.setDate(LocalDate.now().toString());
+        request.setDeadline(LocalDate.now().plusDays(30).toString());
+        request.setCategory("Arts");
+        request.setUser(owner);
+        request.setSupporters(new ArrayList<>());
+        request.setDescription("desc");
+        request.setGoalAmount(100000L);
+
+        ResponseStatusException ex = assertThrows(
+                ResponseStatusException.class,
+                () -> campaignService.updateCampaign(request, "attacker-id")
+        );
+
+        assertEquals(HttpStatus.FORBIDDEN, ex.getStatusCode());
     }
 
     @Test
@@ -294,7 +321,7 @@ class CampaignServiceTest {
 
         ResponseStatusException ex = assertThrows(
                 ResponseStatusException.class,
-                () -> campaignService.updateCampaign(request)
+                () -> campaignService.updateCampaign(request, "user-1")
         );
 
         assertEquals(HttpStatus.CONFLICT, ex.getStatusCode());

--- a/IntegrationTests/src/test/java/com/kenzie/appserver/controller/CampaignControllerTest.java
+++ b/IntegrationTests/src/test/java/com/kenzie/appserver/controller/CampaignControllerTest.java
@@ -121,7 +121,7 @@ class CampaignControllerTest {
 
     @Test
     void updateCampaign_owner_isSuccessful() throws Exception {
-        CampaignResponse created = campaignService.addNewCampaign(buildCreateRequest());
+        CampaignResponse created = campaignService.addNewCampaign(buildCreateRequestOwnedBy(ownerUserId));
 
         CampaignUpdateRequest update = new CampaignUpdateRequest();
         update.setId(created.getId());
@@ -138,6 +138,27 @@ class CampaignControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.name").value(is(update.getName())))
                 .andExpect(jsonPath("$.goalAmount").value(is(300000)));
+    }
+
+    @Test
+    void updateCampaign_nonOwner_returnsForbidden() throws Exception {
+        CampaignResponse created = campaignService.addNewCampaign(buildCreateRequestOwnedBy(ownerUserId));
+
+        String nonOwnerToken = jwtUtil.generateToken(UUID.randomUUID().toString(), "other@test.com");
+
+        CampaignUpdateRequest update = new CampaignUpdateRequest();
+        update.setId(created.getId());
+        update.setName("Hijacked");
+        update.setDate(LocalDate.now().toString());
+        update.setDeadline(LocalDate.now().plusDays(60).toString());
+        update.setCategory("Education");
+        update.setUser(created.getUser());
+        update.setSupporters(new ArrayList<>());
+        update.setDescription("desc");
+        update.setGoalAmount(100000L);
+
+        campaignQueryUtility.campaignControllerClient.updateCampaign(update, nonOwnerToken)
+                .andExpect(status().isForbidden());
     }
 
     /** ------------------------------------------------------------------------
@@ -206,11 +227,7 @@ class CampaignControllerTest {
 
     @Test
     void closeCampaign_owner_isSuccessful() throws Exception {
-        // Build a campaign owned by the same user who holds ownerToken
-        User owner = new User(ownerUserId, "Campaign Owner", "owner@test.com");
-        CreateCampaignRequest request = buildCreateRequest();
-        request.setUser(owner);
-        CampaignResponse created = campaignService.addNewCampaign(request);
+        CampaignResponse created = campaignService.addNewCampaign(buildCreateRequest());
 
         campaignQueryUtility.campaignControllerClient.closeCampaign(created.getId(), ownerToken)
                 .andExpect(status().isOk())
@@ -222,7 +239,11 @@ class CampaignControllerTest {
     // -------------------------------------------------------------------------
 
     private CreateCampaignRequest buildCreateRequest() {
-        User user = new User(UUID.randomUUID().toString(), mockNeat.names().get(), mockNeat.emails().get());
+        return buildCreateRequestOwnedBy(ownerUserId);
+    }
+
+    private CreateCampaignRequest buildCreateRequestOwnedBy(String userId) {
+        User user = new User(userId, mockNeat.names().get(), mockNeat.emails().get());
 
         CreateCampaignRequest request = new CreateCampaignRequest();
         request.setName(mockNeat.names().first().get() + " Campaign");


### PR DESCRIPTION
## Summary

- **Salesforce NPSP integration** — async sync for campaigns, donations, and contacts via OAuth2 client credentials. Disabled by default (`salesforce.enabled=false`); the platform operates normally when Salesforce is unreachable.
- **Integration test suite (20/20)** — rewrote the broken `EventControllerTest` and `UserControllerTest`, added `CampaignControllerTest` covering full CRUD, auth enforcement, donations, and campaign close. Tests use Testcontainers (local DynamoDB) + real JWT auth flow.
- **Production fixes found during testing** — `HttpMessageNotReadableException` now returns 400 instead of 500; `GET /users/**` made public; unauthenticated requests now return 401 instead of 403.

## Changed files

**New — Salesforce**
- `Application/.../salesforce/SalesforceTokenService.java` — OAuth2 client credentials with 1-hour token cache
- `Application/.../salesforce/SalesforceClient.java` — REST client for create/update sobjects
- `Application/.../salesforce/SalesforceService.java` — `@Async` sync for Campaign, Opportunity, Contact
- `Application/.../config/AsyncConfig.java` — enables `@Async`

**Modified — Application**
- `CampaignService` — injected `SalesforceService`; calls `syncCampaign` on create, `syncDonation` on donation
- `UserService` — calls `syncContact` after user registration
- `CampaignRecord` — added `salesforceCampaignId` field
- `GlobalExceptionHandler` — handles `HttpMessageNotReadableException` → 400
- `SecurityConfig` — `GET /users/**` public; `AuthenticationEntryPoint` returns 401 for unauthenticated requests
- `application.properties` — Salesforce connection properties (all placeholders, enabled=false)

**New/Modified — Integration Tests**
- `DynamoDbInitializer` — creates Campaigns and Users tables in Testcontainer before context starts
- `TestTableInitializer` — Spring `ApplicationRunner` that ensures tables exist in the live context
- `CampaignControllerTest` + `CampaignQueryUtility` — 11 tests
- `UserControllerTest` + `UserQueryUtility` — 9 tests (updated for password auth and JWT)
- `IntegrationTests/build.gradle` — upgraded to Spring Boot 3.2.5 BOM, pinned JUnit 5.10.2

## Test plan

- [ ] Run `./gradlew :Application:test` — all 26 unit tests pass
- [ ] Run `./gradlew :IntegrationTests:test` (requires Docker) — all 20 integration tests pass
- [ ] Verify `salesforce.enabled=false` in `application.properties` before deploying
- [ ] In production, set `SALESFORCE_CLIENT_ID`, `SALESFORCE_CLIENT_SECRET`, `SALESFORCE_TOKEN_URL`, `SALESFORCE_INSTANCE_URL` env vars, then flip `salesforce.enabled=true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved campaign synchronization to re-fetch latest record data before persisting Salesforce campaign ID
  * Added warning logging when donation synchronization encounters missing campaign IDs

* **New Features**
  * Campaign update endpoint now validates user ownership and returns 403 Forbidden for non-owners
  * Enhanced Salesforce integration with conditional campaign ID inclusion in donation synchronization
<!-- end of auto-generated comment: release notes by coderabbit.ai -->