### PR TITLE
feat: replace findByEmail table scan with email-index GSI

### DIFF
--- a/Application/src/main/java/com/kenzie/appserver/repositories/UserDao.java
+++ b/Application/src/main/java/com/kenzie/appserver/repositories/UserDao.java
@@ -3,15 +3,12 @@ package com.kenzie.appserver.repositories;
 import com.kenzie.appserver.repositories.model.UserRecord;
 import org.springframework.stereotype.Repository;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbIndex;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
 import software.amazon.awssdk.enhanced.dynamodb.Key;
 import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
+import software.amazon.awssdk.enhanced.dynamodb.model.QueryConditional;
 
-import software.amazon.awssdk.enhanced.dynamodb.model.ScanEnhancedRequest;
-import software.amazon.awssdk.enhanced.dynamodb.Expression;
-import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
-
-import java.util.Map;
 import java.util.Optional;
 
 /** DynamoDB persistence layer for {@link UserRecord}. */
@@ -19,11 +16,14 @@ import java.util.Optional;
 public class UserDao {
 
     private static final String TABLE_NAME = "Users";
+    private static final String EMAIL_INDEX = "email-index";
 
     private final DynamoDbTable<UserRecord> userTable;
+    private final DynamoDbIndex<UserRecord> emailIndex;
 
     public UserDao(DynamoDbEnhancedClient enhancedClient) {
         this.userTable = enhancedClient.table(TABLE_NAME, TableSchema.fromBean(UserRecord.class));
+        this.emailIndex = userTable.index(EMAIL_INDEX);
     }
 
     /**
@@ -69,20 +69,19 @@ public class UserDao {
     }
 
     /**
-     * Finds a user by email address via a filtered full table scan.
-     * This is O(n) — replace with a GSI-backed query when the table grows.
+     * Finds a user by email address using the {@code email-index} GSI.
+     * O(1) DynamoDB query — replaces the previous O(n) full table scan.
+     * Requires the {@code email-index} GSI to exist on the {@code Users} table
+     * (see {@code UsersTable.yml}).
      *
      * @param email the email address to search for
      * @return an Optional containing the matching user, or empty if not found
      */
     public Optional<UserRecord> findByEmail(String email) {
-        Expression filter = Expression.builder()
-                .expression("email = :email")
-                .expressionValues(Map.of(":email", AttributeValue.builder().s(email).build()))
-                .build();
-        return userTable.scan(ScanEnhancedRequest.builder().filterExpression(filter).build())
-                .items()
-                .stream()
+        QueryConditional condition = QueryConditional.keyEqualTo(
+                Key.builder().partitionValue(email).build());
+        return emailIndex.query(condition).stream()
+                .flatMap(page -> page.items().stream())
                 .findFirst();
     }
 }

--- a/Application/src/main/java/com/kenzie/appserver/repositories/model/UserRecord.java
+++ b/Application/src/main/java/com/kenzie/appserver/repositories/model/UserRecord.java
@@ -2,6 +2,7 @@ package com.kenzie.appserver.repositories.model;
 
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbSecondaryPartitionKey;
 
 /**
  * DynamoDB-mapped record for a registered user.
@@ -40,7 +41,8 @@ public class UserRecord {
         this.name = name;
     }
 
-    /** @return the user's email address */
+    /** @return the user's email address (GSI partition key for {@code email-index}) */
+    @DynamoDbSecondaryPartitionKey(indexNames = "email-index")
     public String getEmail() {
         return email;
     }

--- a/UsersTable.yml
+++ b/UsersTable.yml
@@ -2,21 +2,27 @@ Resources:
   UserTable:
     Type: AWS::DynamoDB::Table
     Properties:
-      "AttributeDefinitions":
-        - "AttributeName": "id"
-          "AttributeType": "S"
-        - "AttributeName": "name"
-          "AttributeType": "S"
-        - "AttributeName": "email"
-          "AttributeType": "S"
-      "KeySchema":
-        - "AttributeName": "id"
-          "KeyType": "HASH"
+      AttributeDefinitions:
+        - AttributeName: "id"
+          AttributeType: "S"
+        - AttributeName: "email"
+          AttributeType: "S"
+      KeySchema:
+        - AttributeName: "id"
+          KeyType: "HASH"
+      GlobalSecondaryIndexes:
+        - IndexName: "email-index"
+          KeySchema:
+            - AttributeName: "email"
+              KeyType: "HASH"
+          Projection:
+            ProjectionType: ALL
       PointInTimeRecoverySpecification:
         PointInTimeRecoveryEnabled: false
       BillingMode: PAY_PER_REQUEST
       TableName: "users"
 
 
-#   aws cloudformation create-stack --stack-name lambda-table --template-body file://LambdaExampleTable.yml --capabilities CAPABILITY_IAM   // Example
-#   aws cloudformation create-stack --stack-name users --template-body file://UsersTable.yml --capabilities CAPABILITY_IAM
+# Deploy / update commands:
+#   Create:  aws cloudformation create-stack --stack-name users --template-body file://UsersTable.yml --capabilities CAPABILITY_IAM
+#   Update:  aws cloudformation update-stack --stack-name users --template-body file://UsersTable.yml --capabilities CAPABILITY_IAM


### PR DESCRIPTION
## Summary
- `UserRecord`: adds `@DynamoDbSecondaryPartitionKey(indexNames = "email-index")` to `getEmail()` so the DynamoDB Enhanced Client maps the GSI automatically
- `UserDao`: replaces the O(n) `ScanEnhancedRequest` in `findByEmail` with an O(1) `DynamoDbIndex` query — removes scan-only imports
- `UsersTable.yml`: adds `email-index` GSI (email HASH key, ALL projection, PAY_PER_REQUEST). Also removes the orphaned `name` `AttributeDefinition` that was never referenced by any key or index (DynamoDB rejects these at deploy time)

## Deploy note
The CloudFormation stack must be updated **before** this code change is deployed to production:
```
aws cloudformation update-stack --stack-name users --template-body file://UsersTable.yml --capabilities CAPABILITY_IAM
```
Adding a GSI to an existing table is a non-destructive operation — no data is lost and the table remains available during the update.

## Test plan
- [ ] CI goes green (unit tests mock `userDao.findByEmail`, so no infra needed)
- [ ] Before merging to prod: run the `update-stack` command above and confirm the GSI appears in the DynamoDB console with status ACTIVE
- [ ] Smoke test login flow end-to-end after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Optimized email-based user lookups for faster and more efficient search operations, improving application responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->