### PR TITLE
docs: add mobile strategy and frontend library additions to roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,11 @@ This project demonstrates how a modern, cloud-native application can seamlessly 
 | Vite | Replaces Webpack 4; fast dev server with HMR, optimized production builds |
 | React Router v6 | Client-side routing (replaces 8 separate HTML files) |
 | Axios | HTTP client consuming the Spring Boot REST API (updated from 0.21.x) |
+| TanStack Query | Server-state management — caching, background refetch, stale-data invalidation for live donation totals and campaign status *(Phase 3)* |
+| React Hook Form + Zod | Client-side form validation mirroring Spring Boot Bean Validation; Zod schemas shared with the future React Native app *(Phase 3)* |
+| Radix UI | Headless, accessible UI primitives (modals, dropdowns, accordions) compatible with CSS Modules *(Phase 3)* |
 | CSS Modules | Scoped per-component styles (replaces 6 scattered global CSS files) |
+| vite-plugin-pwa | Web app manifest + service worker; enables "Add to Home Screen" on any device *(Phase 4)* |
 
 ### Pages / Routes
 
@@ -190,9 +194,10 @@ The OpenAPI UI is auto-generated and available at: `http://localhost:5001/swagge
 |---|---|---|
 | **Phase 1 — Architecture Stabilization** | Spring Boot 3 / Java 21, AWS SDK v2, direct DynamoDB access, global exception handling, React + Vite frontend | ✅ Complete |
 | **Phase 2 — Domain Rename & Model Cleanup** | Rename capstone entities to platform domain, eliminate duplicate models, add Bean Validation, proper date types | 🔄 In Progress |
-| **Phase 3 — Feature Completion** | Campaign + event lifecycle, JWT auth / Spring Security, volunteer RSVP, Salesforce integration, frontend auth flow | Planned |
-| **Phase 4 — Platform Enhancements** | Stripe donations, Lambda webhook handler, impact reporting, donor dashboard, Salesforce Data Cloud + Agentforce | Planned |
+| **Phase 3 — Feature Completion** | Campaign lifecycle, JWT auth / Spring Security, volunteer RSVP, Salesforce integration, frontend auth + TanStack Query + React Hook Form + Zod + Radix UI | Planned |
+| **Phase 4 — Platform Enhancements** | Stripe donations, Lambda webhook handler, impact reporting, donor dashboard, PWA, Salesforce Data Cloud + Agentforce | Planned |
 | **Phase 5 — Production Hardening** | CI/CD pipeline, S3 + CloudFront deploy, E2E tests, rate limiting, API Gateway | Planned |
+| **Phase 6 — Mobile** | React Native + Expo donor/volunteer app; Salesforce Lightning Web Components for organizer mobile | Planned |
 
 ### Phase 1 — Architecture Stabilization ✅
 
@@ -221,6 +226,9 @@ The OpenAPI UI is auto-generated and available at: `http://localhost:5001/swagge
 - JWT auth / Spring Security — register, login, role-based access (`ORGANIZER`, `DONOR`)
 - Salesforce REST API integration — sync users, campaigns, and donations as they are created
 - Frontend auth flow — login, register, protected routes, Axios interceptors
+- **TanStack Query** — server-state management; replaces `useEffect` data-fetching with automatic caching, background refetch, and stale-data invalidation (critical when Stripe webhooks or Agentforce updates change donation totals asynchronously)
+- **React Hook Form + Zod** — client-side form validation mirroring the Spring Boot `@Valid` / Bean Validation layer; Zod schemas are shared between the campaign creation form, RSVP flow, and the future React Native app
+- **Radix UI** — headless, fully accessible UI primitives (modals, dropdowns, accordions) that work with CSS Modules without imposing a design system
 
 ### Phase 4 — Platform Enhancements
 
@@ -228,6 +236,7 @@ The OpenAPI UI is auto-generated and available at: `http://localhost:5001/swagge
 - AWS Lambda Stripe webhook handler — processes payment events asynchronously
 - Structured impact reporting — organizers post updates; donors see their contribution's effect
 - Donor dashboard — giving history, volunteer hours, campaigns followed
+- **Progressive Web App (PWA)** — `vite-plugin-pwa` adds a web app manifest and service worker to the existing React/Vite SPA; donors and volunteers can "Add to Home Screen" on any device without an app store; eliminates friction for one-time contributors
 - Salesforce Data Cloud unification — 360° view of community engagement per organizer
 - Agentforce agent — auto-drafts Impact Update posts from real-time campaign data
 
@@ -238,3 +247,19 @@ The OpenAPI UI is auto-generated and available at: `http://localhost:5001/swagge
 - API Gateway — rate limiting, CORS, auth header validation
 - Playwright or Cypress E2E tests covering the critical donor flow
 - CloudWatch dashboards wired via Micrometer for key platform metrics
+
+### Phase 6 — Mobile
+
+Two tracks targeting distinct user groups — built to share maximum logic with the existing web frontend.
+
+**Donor & Volunteer App (React Native + Expo)**
+- Expo abstracts iOS (Xcode) and Android (Android Studio) build complexity
+- Reuses the Zod validation schemas, Axios API client, and JWT auth flow from the web frontend
+- TanStack Query for server-state management is identical API surface on React Native
+- Core flows: browse campaigns, donate (Stripe), volunteer RSVP, push notifications for campaign milestones
+
+**Organizer App (Salesforce Lightning Web Components)**
+- Organizers already live in Salesforce — no separate app download required
+- Custom LWCs expose campaign health, donation velocity, and volunteer pipeline directly in the Salesforce Mobile App
+- As Data Cloud and Agentforce integrations land (Phase 4), LWC surfaces the AI-drafted Impact Updates for organizer review and one-tap publish
+- Zero additional deployment infrastructure: LWCs deploy as part of the Salesforce org

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ This project demonstrates how a modern, cloud-native application can seamlessly 
 | `Application` | Core Spring Boot API. Handles routing, request validation, Caffeine caching, and observability. Connects directly to DynamoDB via AWS SDK v2 Enhanced Client. |
 | `ServiceLambda` | Reserved for Phase 4 — will house the Stripe payment webhook handler. Processes incoming Stripe events asynchronously and writes donation records to DynamoDB and Salesforce. |
 | `ServiceLambdaModel` | Shared domain models used across the Lambda boundary. Will be slimmed down to webhook-specific DTOs in Phase 4. |
-| `ServiceLambdaJavaClient` | Being removed in Phase 1 completion. The Spring Boot app no longer routes through a Lambda proxy for persistence. |
+| `ServiceLambdaJavaClient` | Removed in Phase 1. The Spring Boot app connects directly to DynamoDB via the Enhanced Client — no Lambda proxy. Module retained in the repo tree but excluded from Application dependencies. |
 | `Frontend` | React + Vite SPA. Component-based UI consuming the Spring Boot REST API via Axios. |
 | `IntegrationTests` | Cross-module integration test suites backed by Testcontainers. |
 | `Utilities` | Shared helper functions and build configurations used across the project. |
@@ -212,7 +212,6 @@ The OpenAPI UI is auto-generated and available at: `http://localhost:5001/swagge
 - Add `@Valid` + `@NotBlank` / `@NotNull` to all request DTOs
 - Migrate `date` fields from `String` to `LocalDate`
 - Migrate `CacheStore` from Guava to Caffeine; unify to a single typed cache
-- Remove `ServiceLambdaJavaClient` from Application dependencies
 
 ### Phase 3 — Feature Completion
 
@@ -234,7 +233,7 @@ The OpenAPI UI is auto-generated and available at: `http://localhost:5001/swagge
 
 ### Phase 5 — Production Hardening
 
-- GitHub Actions CI/CD — build, test, deploy on merge to main
+- ✅ GitHub Actions CI — build and unit tests run on every PR and push to main
 - AWS S3 + CloudFront for frontend hosting
 - API Gateway — rate limiting, CORS, auth header validation
 - Playwright or Cypress E2E tests covering the critical donor flow


### PR DESCRIPTION
## Summary
- **Phase 3**: add TanStack Query, React Hook Form + Zod, and Radix UI with rationale for each
- **Phase 4**: add PWA via `vite-plugin-pwa` as the low-friction first mobile step
- **Phase 6 (new)**: two-track mobile strategy — React Native + Expo for donors/volunteers; Salesforce LWC in the Salesforce Mobile App for organizers
- **Frontend stack table**: updated to list all planned tools with phase tags

## Why these choices
- TanStack Query: donation totals change asynchronously via Stripe webhooks and Agentforce — `useEffect` polling doesn't cut it
- Zod schemas are written once and shared between the React web app and the future React Native app
- Radix UI pairs with CSS Modules without imposing a design system
- PWA before native: reduces app-store friction for one-time donors and volunteers ("Add to Home Screen" on any device)
- Salesforce LWC for organizers: they already live in Salesforce — no separate download, and the Phase 4 Data Cloud + Agentforce work becomes the organizer mobile UI automatically

## Test plan
- [ ] Read through the updated roadmap for internal consistency

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project structure documentation to clarify technical organization and module dependencies
  * Added frontend technology stack details with planned libraries and development tools
  * Expanded roadmap with refined phase planning and new mobile development initiatives

<!-- end of auto-generated comment: release notes by coderabbit.ai -->