### PR TITLE
feat: wire Bean Validation and fix email format enforcement

### DIFF
--- a/Application/build.gradle
+++ b/Application/build.gradle
@@ -10,6 +10,7 @@ version = '0.0.1-SNAPSHOT'
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-security'
 
     implementation 'io.jsonwebtoken:jjwt-api:0.12.6'

--- a/Application/src/main/java/com/kenzie/appserver/controller/GlobalExceptionHandler.java
+++ b/Application/src/main/java/com/kenzie/appserver/controller/GlobalExceptionHandler.java
@@ -17,69 +17,85 @@ import java.util.stream.Collectors;
 
 /**
  * Global exception handler for the Application REST API.
-   * Centralizes error response formatting and logging across all controllers.
-   * Replaces scattered ResponseStatusException throws and ad-hoc null checks.
-   */
+ * Centralizes error response formatting and logging across all controllers.
+ * Produces a consistent JSON body: {@code timestamp}, {@code status}, {@code error}, {@code message}.
+ */
 @RestControllerAdvice
-  public class GlobalExceptionHandler {
+public class GlobalExceptionHandler {
 
     private static final Logger log = LoggerFactory.getLogger(GlobalExceptionHandler.class);
 
     /**
-     * Handles Spring's built-in ResponseStatusException (e.g., HttpStatus.BAD_REQUEST, NOT_FOUND).
-       */
+     * Handles Spring's {@link ResponseStatusException} thrown by service and controller layers.
+     *
+     * @param ex the exception carrying the HTTP status and reason phrase
+     * @return a structured error response with the exception's status code
+     */
     @ExceptionHandler(ResponseStatusException.class)
-        public ResponseEntity<Map<String, Object>> handleResponseStatusException(ResponseStatusException ex) {
-                  log.warn("ResponseStatusException: status={}, reason={}", ex.getStatusCode(), ex.getReason());
-                  return buildErrorResponse(HttpStatus.valueOf(ex.getStatusCode().value()), ex.getReason());
-        }
+    public ResponseEntity<Map<String, Object>> handleResponseStatusException(ResponseStatusException ex) {
+        log.warn("ResponseStatusException: status={}, reason={}", ex.getStatusCode(), ex.getReason());
+        return buildErrorResponse(HttpStatus.valueOf(ex.getStatusCode().value()), ex.getReason());
+    }
 
     /**
-     * Handles @Valid / @Validated constraint violations on @RequestBody DTOs.
-         */
+     * Handles {@code @Valid} / {@code @Validated} constraint violations on {@code @RequestBody} DTOs.
+     * Collects all field-level errors into a single comma-separated message.
+     *
+     * @param ex the binding exception containing all field errors
+     * @return 400 with a message listing every failing field and constraint
+     */
     @ExceptionHandler(MethodArgumentNotValidException.class)
-        public ResponseEntity<Map<String, Object>> handleValidationException(MethodArgumentNotValidException ex) {
-                  String fieldErrors = ex.getBindingResult().getFieldErrors().stream()
-                                    .map(fe -> fe.getField() + ": " + fe.getDefaultMessage())
-                                    .collect(Collectors.joining(", "));
-                  log.warn("Validation failed: {}", fieldErrors);
-                  return buildErrorResponse(HttpStatus.BAD_REQUEST, "Validation failed: " + fieldErrors);
-        }
+    public ResponseEntity<Map<String, Object>> handleValidationException(MethodArgumentNotValidException ex) {
+        String fieldErrors = ex.getBindingResult().getFieldErrors().stream()
+                .map(fe -> fe.getField() + ": " + fe.getDefaultMessage())
+                .collect(Collectors.joining(", "));
+        log.warn("Validation failed: {}", fieldErrors);
+        return buildErrorResponse(HttpStatus.BAD_REQUEST, "Validation failed: " + fieldErrors);
+    }
 
     /**
-     * Handles malformed or missing request bodies (e.g., null body, invalid JSON).
-         */
+     * Handles malformed or missing request bodies (e.g., null body, invalid JSON syntax).
+     *
+     * @param ex the parse exception
+     * @return 400 with a generic unreadable-body message (no internal detail leaked)
+     */
     @ExceptionHandler(HttpMessageNotReadableException.class)
-        public ResponseEntity<Map<String, Object>> handleMessageNotReadable(HttpMessageNotReadableException ex) {
-                  log.warn("Unreadable request body: {}", ex.getMessage());
-                  return buildErrorResponse(HttpStatus.BAD_REQUEST, "Request body is missing or malformed");
-        }
+    public ResponseEntity<Map<String, Object>> handleMessageNotReadable(HttpMessageNotReadableException ex) {
+        log.warn("Unreadable request body: {}", ex.getMessage());
+        return buildErrorResponse(HttpStatus.BAD_REQUEST, "Request body is missing or malformed");
+    }
 
     /**
-     * Handles illegal argument exceptions thrown by the service layer (e.g., duplicate id).
-         */
+     * Handles {@link IllegalArgumentException} thrown by the service layer.
+     *
+     * @param ex the exception
+     * @return 400 with the exception message
+     */
     @ExceptionHandler(IllegalArgumentException.class)
-        public ResponseEntity<Map<String, Object>> handleIllegalArgumentException(IllegalArgumentException ex) {
-                  log.warn("IllegalArgumentException: {}", ex.getMessage());
-                  return buildErrorResponse(HttpStatus.BAD_REQUEST, ex.getMessage());
-        }
+    public ResponseEntity<Map<String, Object>> handleIllegalArgumentException(IllegalArgumentException ex) {
+        log.warn("IllegalArgumentException: {}", ex.getMessage());
+        return buildErrorResponse(HttpStatus.BAD_REQUEST, ex.getMessage());
+    }
 
     /**
      * Catch-all handler for any uncaught runtime exceptions.
-         * Returns 500 Internal Server Error without leaking stack trace details.
-       */
+     * Returns 500 without leaking stack trace details to the client.
+     *
+     * @param ex the unhandled exception
+     * @return 500 Internal Server Error
+     */
     @ExceptionHandler(Exception.class)
-        public ResponseEntity<Map<String, Object>> handleGenericException(Exception ex) {
-                  log.error("Unhandled exception: {}", ex.getMessage(), ex);
-                  return buildErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR, "An unexpected error occurred");
-        }
+    public ResponseEntity<Map<String, Object>> handleGenericException(Exception ex) {
+        log.error("Unhandled exception: {}", ex.getMessage(), ex);
+        return buildErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR, "An unexpected error occurred");
+    }
 
     private ResponseEntity<Map<String, Object>> buildErrorResponse(HttpStatus status, String message) {
-              Map<String, Object> body = new LinkedHashMap<>();
-              body.put("timestamp", Instant.now().toString());
-              body.put("status", status.value());
-              body.put("error", status.getReasonPhrase());
-              body.put("message", message);
-              return ResponseEntity.status(status).body(body);
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("timestamp", Instant.now().toString());
+        body.put("status", status.value());
+        body.put("error", status.getReasonPhrase());
+        body.put("message", message);
+        return ResponseEntity.status(status).body(body);
     }
-  }
+}

--- a/Application/src/main/java/com/kenzie/appserver/controller/model/CreateUserRequest.java
+++ b/Application/src/main/java/com/kenzie/appserver/controller/model/CreateUserRequest.java
@@ -3,6 +3,7 @@ package com.kenzie.appserver.controller.model;//package com.kenzie.appserver.con
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.kenzie.appserver.service.model.User;
 
+import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import java.util.List;
 
@@ -14,6 +15,7 @@ public class CreateUserRequest {
     private String name;
 
     @NotBlank
+    @Email
     @JsonProperty("email")
     private String email;
 

--- a/Application/src/main/java/com/kenzie/appserver/controller/model/LoginRequest.java
+++ b/Application/src/main/java/com/kenzie/appserver/controller/model/LoginRequest.java
@@ -1,12 +1,14 @@
 package com.kenzie.appserver.controller.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 
 /** Request body for authenticating a user with email and password. */
 public class LoginRequest {
 
     @NotBlank
+    @Email
     @JsonProperty("email")
     private String email;
 

--- a/Application/src/main/java/com/kenzie/appserver/controller/model/UserUpdateRequest.java
+++ b/Application/src/main/java/com/kenzie/appserver/controller/model/UserUpdateRequest.java
@@ -3,6 +3,7 @@ package com.kenzie.appserver.controller.model;//package com.kenzie.appserver.con
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.kenzie.appserver.service.model.User;
 
+import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import java.util.List;
 
@@ -18,6 +19,7 @@ public class UserUpdateRequest {
     private String name;
 
     @NotBlank
+    @Email
     @JsonProperty("email")
     private String email;
 


### PR DESCRIPTION
## Summary
- **`build.gradle`**: adds `spring-boot-starter-validation` — the critical missing piece. Without this dependency, `@Valid` on controller parameters is silently ignored at runtime even though the annotations compile fine and the DTOs declare them. All existing `@NotBlank` / `@NotNull` / `@Min` annotations were decoration until now.
- **`CreateUserRequest` / `LoginRequest` / `UserUpdateRequest`**: adds `@Email` to each email field alongside the existing `@NotBlank`. `@NotBlank` only checks for non-empty — it accepts `"notanemail"` and `"a@"`. `@Email` rejects malformed addresses before the request reaches the service.
- **`GlobalExceptionHandler`**: reformats severely inconsistent indentation (no logic changes). The `MethodArgumentNotValidException` handler was already collecting field errors and returning a structured 400 with `"Validation failed: field: message"` — it just wasn't readable.

## What this changes at runtime
Before: sending `{"email": "notanemail", "password": "x"}` to `/auth/login` → reaches the service, fails on lookup  
After: Spring returns `400 {"message": "Validation failed: email: must be a well-formed email address"}` before the service is called

## Test plan
- [ ] CI goes green
- [ ] Manual: POST `/users` with a malformed email → 400 with field error message
- [ ] Manual: POST `/users` with a blank name → 400
- [ ] Manual: POST `/campaigns` with `goalAmount: 0` → 400
- [ ] Manual: POST `/campaigns` with a valid body → 201 (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Email field validation now enforces proper format across user account operations (registration, login, and profile updates).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->