### PR TITLE
feat: migrate campaign date fields from String to LocalDate

### DIFF
--- a/Application/src/main/java/com/kenzie/appserver/controller/model/CampaignResponse.java
+++ b/Application/src/main/java/com/kenzie/appserver/controller/model/CampaignResponse.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.kenzie.appserver.service.model.Supporter;
 import com.kenzie.appserver.service.model.User;
 
+import java.time.LocalDate;
 import java.util.List;
 
 /** API response representing a campaign's current state. Monetary fields are in cents. */
@@ -18,10 +19,10 @@ public class CampaignResponse {
     private String name;
 
     @JsonProperty("date")
-    private String date;
+    private LocalDate date;
 
     @JsonProperty("deadline")
-    private String deadline;
+    private LocalDate deadline;
 
     @JsonProperty("category")
     private String category;
@@ -60,15 +61,15 @@ public class CampaignResponse {
     /** @param name the campaign display name */
     public void setName(String name) { this.name = name; }
 
-    /** @return the campaign start date (ISO-8601) */
-    public String getDate() { return date; }
+    /** @return the campaign start date */
+    public LocalDate getDate() { return date; }
     /** @param date the start date */
-    public void setDate(String date) { this.date = date; }
+    public void setDate(LocalDate date) { this.date = date; }
 
-    /** @return the fundraising deadline (ISO-8601) */
-    public String getDeadline() { return deadline; }
+    /** @return the fundraising deadline */
+    public LocalDate getDeadline() { return deadline; }
     /** @param deadline the fundraising deadline */
-    public void setDeadline(String deadline) { this.deadline = deadline; }
+    public void setDeadline(LocalDate deadline) { this.deadline = deadline; }
 
     /** @return the campaign category */
     public String getCategory() { return category; }

--- a/Application/src/main/java/com/kenzie/appserver/controller/model/CampaignUpdateRequest.java
+++ b/Application/src/main/java/com/kenzie/appserver/controller/model/CampaignUpdateRequest.java
@@ -7,6 +7,7 @@ import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
+import java.time.LocalDate;
 import java.util.List;
 
 /** Request body for updating an existing campaign's mutable fields. Monetary amounts are in cents. */
@@ -20,13 +21,13 @@ public class CampaignUpdateRequest {
     @JsonProperty("name")
     private String name;
 
-    @NotBlank
+    @NotNull
     @JsonProperty("date")
-    private String date;
+    private LocalDate date;
 
-    @NotBlank
+    @NotNull
     @JsonProperty("deadline")
-    private String deadline;
+    private LocalDate deadline;
 
     @NotBlank
     @JsonProperty("category")
@@ -64,15 +65,15 @@ public class CampaignUpdateRequest {
     /** @param name the campaign name */
     public void setName(String name) { this.name = name; }
 
-    /** @return the updated start date (ISO-8601) */
-    public String getDate() { return date; }
+    /** @return the updated start date */
+    public LocalDate getDate() { return date; }
     /** @param date the start date */
-    public void setDate(String date) { this.date = date; }
+    public void setDate(LocalDate date) { this.date = date; }
 
-    /** @return the updated deadline (ISO-8601) */
-    public String getDeadline() { return deadline; }
+    /** @return the updated deadline */
+    public LocalDate getDeadline() { return deadline; }
     /** @param deadline the fundraising deadline */
-    public void setDeadline(String deadline) { this.deadline = deadline; }
+    public void setDeadline(LocalDate deadline) { this.deadline = deadline; }
 
     /** @return the updated category */
     public String getCategory() { return category; }

--- a/Application/src/main/java/com/kenzie/appserver/controller/model/CreateCampaignRequest.java
+++ b/Application/src/main/java/com/kenzie/appserver/controller/model/CreateCampaignRequest.java
@@ -7,6 +7,7 @@ import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
+import java.time.LocalDate;
 import java.util.List;
 
 /** Request body for creating a new fundraising campaign. Monetary amounts are in cents. */
@@ -19,13 +20,13 @@ public class CreateCampaignRequest {
     @JsonProperty("name")
     private String name;
 
-    @NotBlank
+    @NotNull
     @JsonProperty("date")
-    private String date;
+    private LocalDate date;
 
-    @NotBlank
+    @NotNull
     @JsonProperty("deadline")
-    private String deadline;
+    private LocalDate deadline;
 
     @NotBlank
     @JsonProperty("category")
@@ -63,15 +64,15 @@ public class CreateCampaignRequest {
     /** @param name the campaign display name */
     public void setName(String name) { this.name = name; }
 
-    /** @return the campaign start date (ISO-8601) */
-    public String getDate() { return date; }
+    /** @return the campaign start date */
+    public LocalDate getDate() { return date; }
     /** @param date the start date */
-    public void setDate(String date) { this.date = date; }
+    public void setDate(LocalDate date) { this.date = date; }
 
-    /** @return the fundraising deadline (ISO-8601) */
-    public String getDeadline() { return deadline; }
+    /** @return the fundraising deadline */
+    public LocalDate getDeadline() { return deadline; }
     /** @param deadline the fundraising deadline */
-    public void setDeadline(String deadline) { this.deadline = deadline; }
+    public void setDeadline(LocalDate deadline) { this.deadline = deadline; }
 
     /** @return the campaign category */
     public String getCategory() { return category; }

--- a/Application/src/main/java/com/kenzie/appserver/repositories/model/CampaignRecord.java
+++ b/Application/src/main/java/com/kenzie/appserver/repositories/model/CampaignRecord.java
@@ -6,6 +6,7 @@ import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbConvertedBy;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
 
+import java.time.LocalDate;
 import java.util.List;
 
 /**
@@ -19,8 +20,8 @@ public class CampaignRecord {
 
     private String id;
     private String name;
-    private String date;
-    private String deadline;
+    private LocalDate date;
+    private LocalDate deadline;
     private String category;
     private User user;
     private List<Supporter> supporters;
@@ -44,15 +45,15 @@ public class CampaignRecord {
     /** @param name the campaign display name */
     public void setName(String name) { this.name = name; }
 
-    /** @return the campaign start date (ISO-8601 string) */
-    public String getDate() { return date; }
+    /** @return the campaign start date */
+    public LocalDate getDate() { return date; }
     /** @param date the campaign start date */
-    public void setDate(String date) { this.date = date; }
+    public void setDate(LocalDate date) { this.date = date; }
 
-    /** @return the fundraising deadline (ISO-8601 string) */
-    public String getDeadline() { return deadline; }
+    /** @return the fundraising deadline */
+    public LocalDate getDeadline() { return deadline; }
     /** @param deadline the fundraising deadline */
-    public void setDeadline(String deadline) { this.deadline = deadline; }
+    public void setDeadline(LocalDate deadline) { this.deadline = deadline; }
 
     /** @return the campaign category (e.g. "Community", "Education") */
     public String getCategory() { return category; }

--- a/Application/src/main/java/com/kenzie/appserver/salesforce/SalesforceService.java
+++ b/Application/src/main/java/com/kenzie/appserver/salesforce/SalesforceService.java
@@ -53,8 +53,8 @@ public class SalesforceService {
             Map<String, Object> fields = new HashMap<>();
             fields.put("Name", record.getName());
             fields.put("Description", record.getDescription());
-            fields.put("StartDate", record.getDate());
-            fields.put("EndDate", record.getDeadline());
+            fields.put("StartDate", record.getDate() != null ? record.getDate().toString() : null);
+            fields.put("EndDate", record.getDeadline() != null ? record.getDeadline().toString() : null);
             fields.put("Type", "Fundraising");
             fields.put("Status", toSalesforceCampaignStatus(record.getStatus()));
             fields.put("ExpectedRevenue", record.getGoalAmount() / 100.0);

--- a/Application/src/main/resources/application.properties
+++ b/Application/src/main/resources/application.properties
@@ -1,4 +1,5 @@
 server.port=5000
+spring.jackson.serialization.write-dates-as-timestamps=false
 
 # Salesforce — set these env vars in production (Spring Boot maps SALESFORCE_CLIENT_ID → salesforce.client-id etc.)
 salesforce.client-id=placeholder

--- a/Application/src/test/java/com/kenzie/appserver/service/CampaignServiceTest.java
+++ b/Application/src/test/java/com/kenzie/appserver/service/CampaignServiceTest.java
@@ -92,8 +92,8 @@ class CampaignServiceTest {
 
         CreateCampaignRequest request = new CreateCampaignRequest();
         request.setName("Send the Wildcats to State Finals");
-        request.setDate(LocalDate.now().toString());
-        request.setDeadline(LocalDate.now().plusDays(30).toString());
+        request.setDate(LocalDate.now());
+        request.setDeadline(LocalDate.now().plusDays(30));
         request.setCategory("Sports");
         request.setUser(user);
         request.setSupporters(new ArrayList<>());
@@ -386,8 +386,8 @@ class CampaignServiceTest {
         CampaignUpdateRequest request = new CampaignUpdateRequest();
         request.setId("camp-10");
         request.setName("Updated Name");
-        request.setDate(LocalDate.now().toString());
-        request.setDeadline(LocalDate.now().plusDays(60).toString());
+        request.setDate(LocalDate.now());
+        request.setDeadline(LocalDate.now().plusDays(60));
         request.setCategory("Arts");
         request.setUser(user);
         request.setSupporters(new ArrayList<>());
@@ -411,8 +411,8 @@ class CampaignServiceTest {
         CampaignUpdateRequest request = new CampaignUpdateRequest();
         request.setId("camp-10b");
         request.setName("Hijacked");
-        request.setDate(LocalDate.now().toString());
-        request.setDeadline(LocalDate.now().plusDays(30).toString());
+        request.setDate(LocalDate.now());
+        request.setDeadline(LocalDate.now().plusDays(30));
         request.setCategory("Arts");
         request.setUser(owner);
         request.setSupporters(new ArrayList<>());
@@ -441,8 +441,8 @@ class CampaignServiceTest {
         request.setUser(user);
         request.setGoalAmount(100000L);
         request.setName("name");
-        request.setDate(LocalDate.now().toString());
-        request.setDeadline(LocalDate.now().plusDays(30).toString());
+        request.setDate(LocalDate.now());
+        request.setDeadline(LocalDate.now().plusDays(30));
         request.setCategory("Sports");
         request.setDescription("desc");
         request.setSupporters(new ArrayList<>());
@@ -530,8 +530,8 @@ class CampaignServiceTest {
         CampaignRecord record = new CampaignRecord();
         record.setId(id);
         record.setName("Test Campaign " + id);
-        record.setDate(LocalDate.now().toString());
-        record.setDeadline(LocalDate.now().plusDays(30).toString());
+        record.setDate(LocalDate.now());
+        record.setDeadline(LocalDate.now().plusDays(30));
         record.setCategory("Community");
         record.setAddress("123 Test St");
         record.setDescription("Test description");

--- a/IntegrationTests/src/test/java/com/kenzie/appserver/controller/CampaignControllerTest.java
+++ b/IntegrationTests/src/test/java/com/kenzie/appserver/controller/CampaignControllerTest.java
@@ -126,8 +126,8 @@ class CampaignControllerTest {
         CampaignUpdateRequest update = new CampaignUpdateRequest();
         update.setId(created.getId());
         update.setName("Updated: " + mockNeat.strings().get());
-        update.setDate(LocalDate.now().toString());
-        update.setDeadline(LocalDate.now().plusDays(60).toString());
+        update.setDate(LocalDate.now());
+        update.setDeadline(LocalDate.now().plusDays(60));
         update.setCategory("Education");
         update.setUser(created.getUser());
         update.setSupporters(new ArrayList<>());
@@ -149,8 +149,8 @@ class CampaignControllerTest {
         CampaignUpdateRequest update = new CampaignUpdateRequest();
         update.setId(created.getId());
         update.setName("Hijacked");
-        update.setDate(LocalDate.now().toString());
-        update.setDeadline(LocalDate.now().plusDays(60).toString());
+        update.setDate(LocalDate.now());
+        update.setDeadline(LocalDate.now().plusDays(60));
         update.setCategory("Education");
         update.setUser(created.getUser());
         update.setSupporters(new ArrayList<>());
@@ -247,8 +247,8 @@ class CampaignControllerTest {
 
         CreateCampaignRequest request = new CreateCampaignRequest();
         request.setName(mockNeat.names().first().get() + " Campaign");
-        request.setDate(LocalDate.now().toString());
-        request.setDeadline(LocalDate.now().plusDays(30).toString());
+        request.setDate(LocalDate.now());
+        request.setDeadline(LocalDate.now().plusDays(30));
         request.setCategory("Community");
         request.setUser(user);
         request.setSupporters(new ArrayList<>());


### PR DESCRIPTION
## Summary
- **`CampaignRecord` / `CampaignResponse`**: `date` and `deadline` are now `LocalDate`. The DynamoDB Enhanced Client's built-in `LocalDateAttributeConverter` reads/writes ISO-8601 strings transparently — no data migration needed for existing records.
- **`CreateCampaignRequest` / `CampaignUpdateRequest`**: field types changed to `LocalDate`; `@NotBlank` replaced with `@NotNull` (`LocalDate` has no notion of blank). Jackson deserializes `"2025-06-01"` directly into `LocalDate`.
- **`application.properties`**: `spring.jackson.serialization.write-dates-as-timestamps=false` — without this, Jackson serializes `LocalDate` as `[2025, 6, 1]` instead of `"2025-06-01"`.
- **`SalesforceService`**: `.toString()` added before inserting dates into the Salesforce field map (which expects plain strings).
- **Tests**: removed `.toString()` from every `setDate` / `setDeadline` call in `CampaignServiceTest` and `CampaignControllerTest`.

## Why this matters
String dates don't sort, can't be compared, and silently accept `"yesterday"` or `"asdf"`. `LocalDate` enforces ISO-8601 at deserialization time — a malformed date string returns a 400 before it ever reaches the service layer.

## Test plan
- [ ] CI goes green
- [ ] Manual: `POST /campaigns` with `"date": "not-a-date"` → 400
- [ ] Manual: `POST /campaigns` with `"date": "2025-06-01"` → 201, response contains `"date": "2025-06-01"` (string, not array)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Enhanced campaign date and deadline handling for improved consistency and standardized ISO-8601 date formatting across API responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->