### PR TITLE
ci: add frontend lint and format check to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
     branches: [ main ]
 
 jobs:
+  # ── Backend: compile + unit tests ──────────────────────────────────────────
   build-and-test:
     name: Build & Unit Tests
     runs-on: ubuntu-latest
@@ -47,3 +48,31 @@ jobs:
           name: unit-test-report
           path: Application/build/reports/tests/test/
           retention-days: 7
+
+  # ── Frontend: lint + format check ──────────────────────────────────────────
+  frontend-lint:
+    name: Frontend Lint & Format
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: Frontend/package-lock.json
+
+      - name: Install dependencies
+        working-directory: Frontend
+        run: npm ci
+
+      - name: ESLint
+        working-directory: Frontend
+        run: npm run lint
+
+      - name: Prettier format check
+        working-directory: Frontend
+        run: npm run format:check


### PR DESCRIPTION
## Summary

Adds a `Frontend Lint & Format` CI job that runs in parallel with the existing `Build & Unit Tests` job.

## Changes

Single file: `.github/workflows/ci.yml`

**New `frontend-lint` job:**
1. Checkout
2. Node 20 setup with npm cache keyed on `Frontend/package-lock.json`
3. `npm ci` — reproducible install (fails on lockfile drift, unlike `npm install`)
4. `npm run lint` — ESLint 9
5. `npm run format:check` — Prettier

## Merge order

This PR depends on #13 (`chore/eslint-prettier`) being merged first — the `lint` and `format:check` scripts are added there. Merge #13 → #14.

## Result

Every PR will show three status checks:
- ✅ Build & Unit Tests  
- ✅ Frontend Lint & Format

The two jobs run in parallel so wall-clock CI time is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced the continuous integration pipeline with automated frontend code quality and formatting checks to maintain consistent code standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->