### PR TITLE
ci: add frontend lint and format check job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
     branches: [ main ]
 
 jobs:
+  # ── Backend: compile + unit tests ──────────────────────────────────────────
   build-and-test:
     name: Build & Unit Tests
     runs-on: ubuntu-latest
@@ -47,3 +48,31 @@ jobs:
           name: unit-test-report
           path: Application/build/reports/tests/test/
           retention-days: 7
+
+  # ── Frontend: lint + format check ──────────────────────────────────────────
+  frontend-lint:
+    name: Frontend Lint & Format
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: Frontend/package-lock.json
+
+      - name: Install dependencies
+        working-directory: Frontend
+        run: npm ci
+
+      - name: ESLint
+        working-directory: Frontend
+        run: npm run lint -- --max-warnings=0
+
+      - name: Prettier format check
+        working-directory: Frontend
+        run: npm run format:check


### PR DESCRIPTION
## Summary

Adds a `Frontend Lint & Format` CI job that runs in parallel with the existing `Build & Unit Tests` job.

Fixes the failed PR #14 — that branch was cut from main before #13 (ESLint/Prettier setup) landed, so the `lint` and `format:check` scripts didn't exist yet. This branch is cut from main *after* #13 merged, so both scripts are present and verified.

## Changes

Single file: `.github/workflows/ci.yml`

**New `frontend-lint` job:**
1. Node 22 setup with npm cache keyed on `Frontend/package-lock.json` — avoids the Node 20 deprecation warning flagged in the previous run
2. `npm ci` — reproducible install
3. `npm run lint -- --max-warnings=0` — ESLint; warnings are treated as errors so they can't silently accumulate
4. `npm run format:check` — Prettier

## Verified locally
```
npm run lint        → 0 errors, 0 warnings
npm run format:check → All matched files use Prettier code style!
```

## Result
Every PR shows two parallel status checks:
- ✅ Build & Unit Tests
- ✅ Frontend Lint & Format

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD pipeline with dedicated frontend linting job that enforces code quality standards and formatting consistency through automated checks, improving overall code maintainability across the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->