### PR TITLE
feat: FundraisingEvent entity + volunteer RSVP flow (Phase 3)

### DIFF
--- a/Application/src/main/java/com/kenzie/appserver/config/CacheConfig.java
+++ b/Application/src/main/java/com/kenzie/appserver/config/CacheConfig.java
@@ -1,13 +1,21 @@
 package com.kenzie.appserver.config;
 
+import com.kenzie.appserver.repositories.model.CampaignRecord;
+import com.kenzie.appserver.repositories.model.FundraisingEventRecord;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.cache.annotation.EnableCaching;
 
 import java.util.concurrent.TimeUnit;
 
 /**
- * Spring configuration that registers the {@link CacheStore} bean.
+ * Spring configuration that registers typed {@link CacheStore} beans.
+ *
+ * <p>Each bean is named so services can inject the correct type via {@code @Qualifier}:
+ * <ul>
+ *   <li>{@code "campaignCache"} — used by {@link com.kenzie.appserver.service.CampaignService}</li>
+ *   <li>{@code "eventCache"} — used by {@link com.kenzie.appserver.service.FundraisingEventService}</li>
+ * </ul>
  */
 @Configuration
 @EnableCaching
@@ -16,10 +24,20 @@ public class CacheConfig {
     /**
      * Campaign cache with a 3-minute write expiry.
      *
-     * @return the CacheStore bean
+     * @return the CacheStore bean for campaigns
      */
-    @Bean
-    public CacheStore myCache() {
-        return new CacheStore(180, TimeUnit.SECONDS);
+    @Bean("campaignCache")
+    public CacheStore<CampaignRecord> campaignCache() {
+        return new CacheStore<>(180, TimeUnit.SECONDS);
+    }
+
+    /**
+     * Fundraising event cache with a 3-minute write expiry.
+     *
+     * @return the CacheStore bean for fundraising events
+     */
+    @Bean("eventCache")
+    public CacheStore<FundraisingEventRecord> eventCache() {
+        return new CacheStore<>(180, TimeUnit.SECONDS);
     }
 }

--- a/Application/src/main/java/com/kenzie/appserver/config/CacheStore.java
+++ b/Application/src/main/java/com/kenzie/appserver/config/CacheStore.java
@@ -2,19 +2,26 @@ package com.kenzie.appserver.config;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
-import com.kenzie.appserver.repositories.model.CampaignRecord;
 
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 /**
- * In-memory Caffeine cache for {@link CampaignRecord} lookups.
+ * Generic in-memory Caffeine cache for DynamoDB record lookups.
  * Caches both hits (present Optional) and misses (empty Optional) to prevent
  * repeated DynamoDB calls for non-existent IDs.
+ *
+ * <p>Typed beans are registered in {@link CacheConfig}:
+ * <ul>
+ *   <li>{@code "campaignCache"} → {@code CacheStore<CampaignRecord>}</li>
+ *   <li>{@code "eventCache"} → {@code CacheStore<FundraisingEventRecord>}</li>
+ * </ul>
+ *
+ * @param <T> the DynamoDB record type stored in this cache
  */
-public class CacheStore {
+public class CacheStore<T> {
 
-    private final Cache<String, Optional<CampaignRecord>> cache;
+    private final Cache<String, Optional<T>> cache;
 
     public CacheStore(int expiry, TimeUnit timeUnit) {
         this.cache = Caffeine.newBuilder()
@@ -26,27 +33,27 @@ public class CacheStore {
      * Returns the cached value for the given key, or {@code null} if the key is not cached.
      * A return value of {@code Optional.empty()} means the key was cached as a miss.
      *
-     * @param key the campaign ID
+     * @param key the record ID (may include a namespace prefix, e.g. {@code "event:uuid"})
      * @return the cached Optional, or {@code null} if absent from the cache
      */
-    public Optional<CampaignRecord> get(String key) {
+    public Optional<T> get(String key) {
         return cache.getIfPresent(key);
     }
 
     /**
      * Stores a value in the cache, including empty Optionals for miss caching.
      *
-     * @param key   the campaign ID
+     * @param key   the record ID
      * @param value the record wrapped in Optional (empty for misses)
      */
-    public void add(String key, Optional<CampaignRecord> value) {
+    public void add(String key, Optional<T> value) {
         cache.put(key, value);
     }
 
     /**
      * Removes the entry for the given key, forcing the next read to go to DynamoDB.
      *
-     * @param key the campaign ID to evict
+     * @param key the record ID to evict
      */
     public void evict(String key) {
         cache.invalidate(key);

--- a/Application/src/main/java/com/kenzie/appserver/controller/FundraisingEventController.java
+++ b/Application/src/main/java/com/kenzie/appserver/controller/FundraisingEventController.java
@@ -1,0 +1,185 @@
+package com.kenzie.appserver.controller;
+
+import com.kenzie.appserver.controller.model.CreateEventRequest;
+import com.kenzie.appserver.controller.model.EventResponse;
+import com.kenzie.appserver.controller.model.EventUpdateRequest;
+import com.kenzie.appserver.controller.model.RsvpRequest;
+import com.kenzie.appserver.service.FundraisingEventService;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
+import java.util.List;
+
+/**
+ * REST controller for fundraising event CRUD and volunteer RSVP.
+ *
+ * <p>Security model:
+ * <ul>
+ *   <li>GET endpoints are public (read-only event discovery)</li>
+ *   <li>POST /events and PUT /events require a valid JWT</li>
+ *   <li>POST /events/{id}/publish and /cancel require JWT + organizer ownership</li>
+ *   <li>POST /events/{id}/rsvp requires a valid JWT (volunteer identity from JWT)</li>
+ *   <li>DELETE /events/{id}/rsvp requires JWT matching the volunteerId path param</li>
+ * </ul>
+ */
+@RestController
+@RequestMapping("/events")
+public class FundraisingEventController {
+
+    private final FundraisingEventService eventService;
+
+    FundraisingEventController(FundraisingEventService eventService) {
+        this.eventService = eventService;
+    }
+
+    /**
+     * {@code GET /events/{id}} — returns a single event by ID.
+     * Public endpoint.
+     *
+     * @param id the event ID
+     * @return 200 with the event, or 404 if not found
+     */
+    @GetMapping("/{id}")
+    public ResponseEntity<EventResponse> getEventById(@PathVariable("id") String id) {
+        return ResponseEntity.ok(eventService.getEventById(id));
+    }
+
+    /**
+     * {@code GET /events/all} — returns all events.
+     * Public endpoint. Full table scan — avoid high-frequency polling.
+     *
+     * @return 200 with the list of all events
+     */
+    @GetMapping("/all")
+    public ResponseEntity<List<EventResponse>> getAllEvents() {
+        return ResponseEntity.ok(eventService.getAllEvents());
+    }
+
+    /**
+     * {@code GET /events/campaign/{campaignId}} — returns all events for a campaign.
+     * Public endpoint.
+     *
+     * @param campaignId the campaign ID
+     * @return 200 with matching events
+     */
+    @GetMapping("/campaign/{campaignId}")
+    public ResponseEntity<List<EventResponse>> getEventsByCampaign(
+            @PathVariable("campaignId") String campaignId) {
+        return ResponseEntity.ok(eventService.getEventsByCampaign(campaignId));
+    }
+
+    /**
+     * {@code POST /events} — creates a new event in PLANNING status.
+     * Requires a valid JWT. Returns 201 with a Location header.
+     *
+     * @param request the event creation payload
+     * @return 201 with the created event
+     */
+    @PostMapping
+    public ResponseEntity<EventResponse> createEvent(@Valid @RequestBody CreateEventRequest request) {
+        EventResponse response = eventService.createEvent(request);
+        return ResponseEntity.created(URI.create("/events/" + response.getId())).body(response);
+    }
+
+    /**
+     * {@code PUT /events/{id}} — updates an event's mutable fields.
+     * Requires a valid JWT; caller must be the organizer.
+     *
+     * @param request        the update payload (must include the event ID)
+     * @param authentication the authenticated principal
+     * @return 200 with the updated event
+     */
+    @PutMapping("/{id}")
+    public ResponseEntity<EventResponse> updateEvent(
+            @Valid @RequestBody EventUpdateRequest request,
+            Authentication authentication) {
+        EventResponse response = eventService.updateEvent(request, authentication.getName());
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * {@code POST /events/{id}/publish} — moves an event from PLANNING to SCHEDULED.
+     * Requires a valid JWT; caller must be the organizer.
+     *
+     * @param id             the event ID to publish
+     * @param authentication the authenticated principal
+     * @return 200 with the updated event
+     */
+    @PostMapping("/{id}/publish")
+    public ResponseEntity<EventResponse> publishEvent(
+            @PathVariable("id") String id,
+            Authentication authentication) {
+        return ResponseEntity.ok(eventService.publishEvent(id, authentication.getName()));
+    }
+
+    /**
+     * {@code POST /events/{id}/cancel} — cancels a SCHEDULED or IN_PROGRESS event.
+     * Requires a valid JWT; caller must be the organizer.
+     *
+     * @param id             the event ID to cancel
+     * @param authentication the authenticated principal
+     * @return 200 with the cancelled event
+     */
+    @PostMapping("/{id}/cancel")
+    public ResponseEntity<EventResponse> cancelEvent(
+            @PathVariable("id") String id,
+            Authentication authentication) {
+        return ResponseEntity.ok(eventService.cancelEvent(id, authentication.getName()));
+    }
+
+    /**
+     * {@code DELETE /events/{id}} — permanently deletes a PLANNING-status event.
+     * Requires a valid JWT; caller must be the organizer.
+     *
+     * @param id             the event ID to delete
+     * @param authentication the authenticated principal
+     * @return 204 on success
+     */
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteEvent(
+            @PathVariable("id") String id,
+            Authentication authentication) {
+        eventService.deleteEvent(id, authentication.getName());
+        return ResponseEntity.noContent().build();
+    }
+
+    /**
+     * {@code POST /events/{id}/rsvp} — submits a volunteer RSVP.
+     * The volunteer is CONFIRMED if spots remain; otherwise WAITLISTED.
+     * Requires a valid JWT.
+     *
+     * @param id             the event ID to RSVP to
+     * @param request        the volunteer details
+     * @param authentication the authenticated principal (used for JWT ownership verification
+     *                       in {@link com.kenzie.appserver.service.FundraisingEventService})
+     * @return 200 with the updated event
+     */
+    @PostMapping("/{id}/rsvp")
+    public ResponseEntity<EventResponse> rsvp(
+            @PathVariable("id") String id,
+            @Valid @RequestBody RsvpRequest request,
+            Authentication authentication) {
+        return ResponseEntity.ok(eventService.rsvp(id, request));
+    }
+
+    /**
+     * {@code DELETE /events/{id}/rsvp/{volunteerId}} — cancels a volunteer's RSVP.
+     * The first waitlisted volunteer is automatically promoted when a confirmed spot opens.
+     * Requires a valid JWT; the JWT subject must match {@code volunteerId}.
+     *
+     * @param id             the event ID
+     * @param volunteerId    the volunteer's user ID
+     * @param authentication the authenticated principal
+     * @return 200 with the updated event
+     */
+    @DeleteMapping("/{id}/rsvp/{volunteerId}")
+    public ResponseEntity<EventResponse> cancelRsvp(
+            @PathVariable("id") String id,
+            @PathVariable("volunteerId") String volunteerId,
+            Authentication authentication) {
+        return ResponseEntity.ok(eventService.cancelRsvp(id, volunteerId, authentication.getName()));
+    }
+}

--- a/Application/src/main/java/com/kenzie/appserver/controller/model/CreateEventRequest.java
+++ b/Application/src/main/java/com/kenzie/appserver/controller/model/CreateEventRequest.java
@@ -1,0 +1,87 @@
+package com.kenzie.appserver.controller.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.kenzie.appserver.service.model.User;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalDate;
+
+/** Request body for creating a new fundraising event. */
+public class CreateEventRequest {
+
+    @NotBlank
+    @JsonProperty("campaignId")
+    private String campaignId;
+
+    @NotBlank
+    @JsonProperty("name")
+    private String name;
+
+    @JsonProperty("description")
+    private String description;
+
+    @JsonProperty("location")
+    private String location;
+
+    @NotNull
+    @JsonProperty("eventDate")
+    private LocalDate eventDate;
+
+    @NotNull
+    @JsonProperty("registrationDeadline")
+    private LocalDate registrationDeadline;
+
+    @Min(1)
+    @JsonProperty("capacity")
+    private Integer capacity;
+
+    @NotNull
+    @JsonProperty("organizer")
+    private User organizer;
+
+    public CreateEventRequest() {}
+
+    /** @return the ID of the campaign this event belongs to */
+    public String getCampaignId() { return campaignId; }
+    /** @param campaignId the campaign ID */
+    public void setCampaignId(String campaignId) { this.campaignId = campaignId; }
+
+    /** @return the event display name */
+    public String getName() { return name; }
+    /** @param name the event display name */
+    public void setName(String name) { this.name = name; }
+
+    /** @return the event description */
+    public String getDescription() { return description; }
+    /** @param description the event description */
+    public void setDescription(String description) { this.description = description; }
+
+    /** @return the event location */
+    public String getLocation() { return location; }
+    /** @param location the event location */
+    public void setLocation(String location) { this.location = location; }
+
+    /** @return the date of the event */
+    public LocalDate getEventDate() { return eventDate; }
+    /** @param eventDate the event date */
+    public void setEventDate(LocalDate eventDate) { this.eventDate = eventDate; }
+
+    /** @return the RSVP deadline */
+    public LocalDate getRegistrationDeadline() { return registrationDeadline; }
+    /** @param registrationDeadline the RSVP deadline */
+    public void setRegistrationDeadline(LocalDate registrationDeadline) {
+        this.registrationDeadline = registrationDeadline;
+    }
+
+    /** @return the maximum number of confirmed volunteers; {@code null} means unlimited */
+    public Integer getCapacity() { return capacity; }
+    /** @param capacity the volunteer capacity */
+    public void setCapacity(Integer capacity) { this.capacity = capacity; }
+
+    /** @return the event organizer */
+    public User getOrganizer() { return organizer; }
+    /** @param organizer the event organizer */
+    public void setOrganizer(User organizer) { this.organizer = organizer; }
+}

--- a/Application/src/main/java/com/kenzie/appserver/controller/model/EventResponse.java
+++ b/Application/src/main/java/com/kenzie/appserver/controller/model/EventResponse.java
@@ -1,0 +1,128 @@
+package com.kenzie.appserver.controller.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.kenzie.appserver.service.model.User;
+import com.kenzie.appserver.service.model.Volunteer;
+
+import java.time.LocalDate;
+import java.util.List;
+
+/** Response body for a fundraising event. */
+public class EventResponse {
+
+    @JsonProperty("id")
+    private String id;
+
+    @JsonProperty("campaignId")
+    private String campaignId;
+
+    @JsonProperty("name")
+    private String name;
+
+    @JsonProperty("description")
+    private String description;
+
+    @JsonProperty("location")
+    private String location;
+
+    @JsonProperty("eventDate")
+    private LocalDate eventDate;
+
+    @JsonProperty("registrationDeadline")
+    private LocalDate registrationDeadline;
+
+    @JsonProperty("capacity")
+    private Integer capacity;
+
+    @JsonProperty("organizer")
+    private User organizer;
+
+    @JsonProperty("volunteers")
+    private List<Volunteer> volunteers;
+
+    @JsonProperty("status")
+    private String status;
+
+    @JsonProperty("confirmedCount")
+    private int confirmedCount;
+
+    @JsonProperty("waitlistedCount")
+    private int waitlistedCount;
+
+    @JsonProperty("spotsRemaining")
+    private Integer spotsRemaining; // null when capacity is unlimited
+
+    public EventResponse() {}
+
+    /** @return the event ID */
+    public String getId() { return id; }
+    /** @param id the event ID */
+    public void setId(String id) { this.id = id; }
+
+    /** @return the campaign ID */
+    public String getCampaignId() { return campaignId; }
+    /** @param campaignId the campaign ID */
+    public void setCampaignId(String campaignId) { this.campaignId = campaignId; }
+
+    /** @return the event display name */
+    public String getName() { return name; }
+    /** @param name the event display name */
+    public void setName(String name) { this.name = name; }
+
+    /** @return the event description */
+    public String getDescription() { return description; }
+    /** @param description the event description */
+    public void setDescription(String description) { this.description = description; }
+
+    /** @return the event location */
+    public String getLocation() { return location; }
+    /** @param location the event location */
+    public void setLocation(String location) { this.location = location; }
+
+    /** @return the event date */
+    public LocalDate getEventDate() { return eventDate; }
+    /** @param eventDate the event date */
+    public void setEventDate(LocalDate eventDate) { this.eventDate = eventDate; }
+
+    /** @return the RSVP deadline */
+    public LocalDate getRegistrationDeadline() { return registrationDeadline; }
+    /** @param registrationDeadline the RSVP deadline */
+    public void setRegistrationDeadline(LocalDate registrationDeadline) {
+        this.registrationDeadline = registrationDeadline;
+    }
+
+    /** @return the volunteer capacity; {@code null} means unlimited */
+    public Integer getCapacity() { return capacity; }
+    /** @param capacity the volunteer capacity */
+    public void setCapacity(Integer capacity) { this.capacity = capacity; }
+
+    /** @return the event organizer */
+    public User getOrganizer() { return organizer; }
+    /** @param organizer the event organizer */
+    public void setOrganizer(User organizer) { this.organizer = organizer; }
+
+    /** @return all RSVP records */
+    public List<Volunteer> getVolunteers() { return volunteers; }
+    /** @param volunteers all RSVP records */
+    public void setVolunteers(List<Volunteer> volunteers) { this.volunteers = volunteers; }
+
+    /** @return the event status name */
+    public String getStatus() { return status; }
+    /** @param status the event status name */
+    public void setStatus(String status) { this.status = status; }
+
+    /** @return the number of confirmed volunteers */
+    public int getConfirmedCount() { return confirmedCount; }
+    /** @param confirmedCount the confirmed volunteer count */
+    public void setConfirmedCount(int confirmedCount) { this.confirmedCount = confirmedCount; }
+
+    /** @return the number of waitlisted volunteers */
+    public int getWaitlistedCount() { return waitlistedCount; }
+    /** @param waitlistedCount the waitlisted volunteer count */
+    public void setWaitlistedCount(int waitlistedCount) { this.waitlistedCount = waitlistedCount; }
+
+    /** @return remaining confirmed spots; {@code null} when capacity is unlimited */
+    public Integer getSpotsRemaining() { return spotsRemaining; }
+    /** @param spotsRemaining the remaining confirmed spots */
+    public void setSpotsRemaining(Integer spotsRemaining) { this.spotsRemaining = spotsRemaining; }
+}

--- a/Application/src/main/java/com/kenzie/appserver/controller/model/EventUpdateRequest.java
+++ b/Application/src/main/java/com/kenzie/appserver/controller/model/EventUpdateRequest.java
@@ -1,0 +1,77 @@
+package com.kenzie.appserver.controller.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalDate;
+
+/** Request body for updating the mutable fields of an existing fundraising event. */
+public class EventUpdateRequest {
+
+    @NotBlank
+    @JsonProperty("id")
+    private String id;
+
+    @NotBlank
+    @JsonProperty("name")
+    private String name;
+
+    @JsonProperty("description")
+    private String description;
+
+    @JsonProperty("location")
+    private String location;
+
+    @NotNull
+    @JsonProperty("eventDate")
+    private LocalDate eventDate;
+
+    @NotNull
+    @JsonProperty("registrationDeadline")
+    private LocalDate registrationDeadline;
+
+    @Min(1)
+    @JsonProperty("capacity")
+    private Integer capacity;
+
+    public EventUpdateRequest() {}
+
+    /** @return the event ID to update */
+    public String getId() { return id; }
+    /** @param id the event ID */
+    public void setId(String id) { this.id = id; }
+
+    /** @return the updated event name */
+    public String getName() { return name; }
+    /** @param name the updated event name */
+    public void setName(String name) { this.name = name; }
+
+    /** @return the updated event description */
+    public String getDescription() { return description; }
+    /** @param description the updated description */
+    public void setDescription(String description) { this.description = description; }
+
+    /** @return the updated event location */
+    public String getLocation() { return location; }
+    /** @param location the updated location */
+    public void setLocation(String location) { this.location = location; }
+
+    /** @return the updated event date */
+    public LocalDate getEventDate() { return eventDate; }
+    /** @param eventDate the updated event date */
+    public void setEventDate(LocalDate eventDate) { this.eventDate = eventDate; }
+
+    /** @return the updated RSVP deadline */
+    public LocalDate getRegistrationDeadline() { return registrationDeadline; }
+    /** @param registrationDeadline the updated RSVP deadline */
+    public void setRegistrationDeadline(LocalDate registrationDeadline) {
+        this.registrationDeadline = registrationDeadline;
+    }
+
+    /** @return the updated capacity; {@code null} means unlimited */
+    public Integer getCapacity() { return capacity; }
+    /** @param capacity the updated capacity */
+    public void setCapacity(Integer capacity) { this.capacity = capacity; }
+}

--- a/Application/src/main/java/com/kenzie/appserver/controller/model/RsvpRequest.java
+++ b/Application/src/main/java/com/kenzie/appserver/controller/model/RsvpRequest.java
@@ -1,0 +1,39 @@
+package com.kenzie.appserver.controller.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+/** Request body for a volunteer RSVP submission. */
+public class RsvpRequest {
+
+    @NotBlank
+    @JsonProperty("volunteerId")
+    private String volunteerId;
+
+    @NotBlank
+    @JsonProperty("volunteerName")
+    private String volunteerName;
+
+    @NotBlank
+    @Email
+    @JsonProperty("volunteerEmail")
+    private String volunteerEmail;
+
+    public RsvpRequest() {}
+
+    /** @return the volunteer's user ID */
+    public String getVolunteerId() { return volunteerId; }
+    /** @param volunteerId the volunteer's user ID */
+    public void setVolunteerId(String volunteerId) { this.volunteerId = volunteerId; }
+
+    /** @return the volunteer's display name */
+    public String getVolunteerName() { return volunteerName; }
+    /** @param volunteerName the volunteer's display name */
+    public void setVolunteerName(String volunteerName) { this.volunteerName = volunteerName; }
+
+    /** @return the volunteer's email address */
+    public String getVolunteerEmail() { return volunteerEmail; }
+    /** @param volunteerEmail the volunteer's email address */
+    public void setVolunteerEmail(String volunteerEmail) { this.volunteerEmail = volunteerEmail; }
+}

--- a/Application/src/main/java/com/kenzie/appserver/repositories/FundraisingEventDao.java
+++ b/Application/src/main/java/com/kenzie/appserver/repositories/FundraisingEventDao.java
@@ -1,0 +1,95 @@
+package com.kenzie.appserver.repositories;
+
+import com.kenzie.appserver.repositories.model.FundraisingEventRecord;
+import org.springframework.stereotype.Repository;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
+import software.amazon.awssdk.enhanced.dynamodb.Key;
+import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
+import software.amazon.awssdk.enhanced.dynamodb.model.ScanEnhancedRequest;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/** DynamoDB persistence layer for {@link FundraisingEventRecord}. */
+@Repository
+public class FundraisingEventDao {
+
+    private static final String TABLE_NAME = "FundraisingEvents";
+
+    private final DynamoDbTable<FundraisingEventRecord> eventTable;
+
+    public FundraisingEventDao(DynamoDbEnhancedClient enhancedClient) {
+        this.eventTable = enhancedClient.table(TABLE_NAME,
+                TableSchema.fromBean(FundraisingEventRecord.class));
+    }
+
+    /**
+     * Looks up an event by its partition key.
+     *
+     * @param id the event ID
+     * @return an Optional containing the record, or empty if not found
+     */
+    public Optional<FundraisingEventRecord> findById(String id) {
+        Key key = Key.builder().partitionValue(id).build();
+        return Optional.ofNullable(eventTable.getItem(key));
+    }
+
+    /**
+     * Persists an event record (insert or full replace).
+     *
+     * @param record the record to save
+     * @return the saved record
+     */
+    public FundraisingEventRecord save(FundraisingEventRecord record) {
+        eventTable.putItem(record);
+        return record;
+    }
+
+    /**
+     * Deletes the event with the given ID. No-op if the item does not exist.
+     *
+     * @param id the event ID to delete
+     */
+    public void deleteById(String id) {
+        Key key = Key.builder().partitionValue(id).build();
+        eventTable.deleteItem(key);
+    }
+
+    /**
+     * Returns {@code true} if an event with the given ID exists in the table.
+     *
+     * @param id the event ID
+     * @return {@code true} if found
+     */
+    public boolean existsById(String id) {
+        return findById(id).isPresent();
+    }
+
+    /**
+     * Returns all events via a full table scan.
+     * Avoid at large data volumes — prefer paginated or filtered queries.
+     *
+     * @return list of all event records
+     */
+    public List<FundraisingEventRecord> findAll() {
+        return eventTable.scan(ScanEnhancedRequest.builder().build())
+                .items()
+                .stream()
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Returns all events associated with a given campaign.
+     * Uses a full table scan with client-side filter — add a GSI on {@code campaignId} at scale.
+     *
+     * @param campaignId the campaign ID to filter by
+     * @return list of matching event records
+     */
+    public List<FundraisingEventRecord> findByCampaignId(String campaignId) {
+        return findAll().stream()
+                .filter(r -> campaignId.equals(r.getCampaignId()))
+                .collect(Collectors.toList());
+    }
+}

--- a/Application/src/main/java/com/kenzie/appserver/repositories/model/FundraisingEventRecord.java
+++ b/Application/src/main/java/com/kenzie/appserver/repositories/model/FundraisingEventRecord.java
@@ -1,0 +1,96 @@
+package com.kenzie.appserver.repositories.model;
+
+import com.kenzie.appserver.service.model.User;
+import com.kenzie.appserver.service.model.Volunteer;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbConvertedBy;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
+
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * DynamoDB-mapped record for a fundraising event.
+ *
+ * <p>An event is a physical or virtual volunteer activity linked to a campaign.
+ * {@code status} holds an {@link com.kenzie.appserver.service.model.EventStatus} name.
+ * {@code organizer} is the User who created the event, serialised via {@link UserTypeConverter}.
+ * {@code volunteers} is the list of RSVPs, serialised via {@link VolunteerTypeConverter}.
+ */
+@DynamoDbBean
+public class FundraisingEventRecord {
+
+    private String id;
+    private String campaignId;
+    private String name;
+    private String description;
+    private String location;
+    private LocalDate eventDate;
+    private LocalDate registrationDeadline;
+    private Integer capacity;
+    private User organizer;
+    private List<Volunteer> volunteers;
+    private String status; // EventStatus name()
+
+    public FundraisingEventRecord() {}
+
+    /** @return the event's unique ID (partition key) */
+    @DynamoDbPartitionKey
+    public String getId() { return id; }
+    /** @param id the event ID */
+    public void setId(String id) { this.id = id; }
+
+    /** @return the ID of the campaign this event belongs to */
+    public String getCampaignId() { return campaignId; }
+    /** @param campaignId the campaign ID */
+    public void setCampaignId(String campaignId) { this.campaignId = campaignId; }
+
+    /** @return the event display name */
+    public String getName() { return name; }
+    /** @param name the event display name */
+    public void setName(String name) { this.name = name; }
+
+    /** @return the event description */
+    public String getDescription() { return description; }
+    /** @param description the event description */
+    public void setDescription(String description) { this.description = description; }
+
+    /** @return the event location (address or virtual URL) */
+    public String getLocation() { return location; }
+    /** @param location the event location */
+    public void setLocation(String location) { this.location = location; }
+
+    /** @return the date of the event */
+    public LocalDate getEventDate() { return eventDate; }
+    /** @param eventDate the event date */
+    public void setEventDate(LocalDate eventDate) { this.eventDate = eventDate; }
+
+    /** @return the last date volunteers may RSVP */
+    public LocalDate getRegistrationDeadline() { return registrationDeadline; }
+    /** @param registrationDeadline the RSVP deadline */
+    public void setRegistrationDeadline(LocalDate registrationDeadline) {
+        this.registrationDeadline = registrationDeadline;
+    }
+
+    /** @return the maximum number of CONFIRMED volunteers; {@code null} means unlimited */
+    public Integer getCapacity() { return capacity; }
+    /** @param capacity the volunteer capacity */
+    public void setCapacity(Integer capacity) { this.capacity = capacity; }
+
+    /** @return the event organizer; stored via {@link UserTypeConverter} */
+    @DynamoDbConvertedBy(UserTypeConverter.class)
+    public User getOrganizer() { return organizer; }
+    /** @param organizer the event organizer */
+    public void setOrganizer(User organizer) { this.organizer = organizer; }
+
+    /** @return the list of RSVPs; stored via {@link VolunteerTypeConverter} */
+    @DynamoDbConvertedBy(VolunteerTypeConverter.class)
+    public List<Volunteer> getVolunteers() { return volunteers; }
+    /** @param volunteers the list of RSVPs */
+    public void setVolunteers(List<Volunteer> volunteers) { this.volunteers = volunteers; }
+
+    /** @return the event status name (see {@link com.kenzie.appserver.service.model.EventStatus}) */
+    public String getStatus() { return status; }
+    /** @param status the event status name */
+    public void setStatus(String status) { this.status = status; }
+}

--- a/Application/src/main/java/com/kenzie/appserver/repositories/model/VolunteerTypeConverter.java
+++ b/Application/src/main/java/com/kenzie/appserver/repositories/model/VolunteerTypeConverter.java
@@ -1,0 +1,78 @@
+package com.kenzie.appserver.repositories.model;
+
+import com.kenzie.appserver.service.model.Volunteer;
+import software.amazon.awssdk.enhanced.dynamodb.AttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.AttributeValueType;
+import software.amazon.awssdk.enhanced.dynamodb.EnhancedType;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * DynamoDB {@link AttributeConverter} for {@code List<Volunteer>}.
+ *
+ * <p>Each volunteer is serialised as a pipe-delimited string:
+ * {@code "id|name|email|rsvpStatus"} and stored in a DynamoDB List ({@code L}).
+ * Pipe ({@code |}) was chosen over {@code x} (used by {@link SupporterTypeConverter}) to
+ * avoid ambiguity with names that contain the letter 'x'.
+ */
+public class VolunteerTypeConverter implements AttributeConverter<List<Volunteer>> {
+
+    private static final String DELIMITER = "|";
+    private static final String DELIMITER_REGEX = "\\|";
+
+    /**
+     * Converts a list of volunteers to a DynamoDB AttributeValue (List type).
+     *
+     * @param input the list of volunteers, or {@code null}
+     * @return a DynamoDB AttributeValue containing the serialised volunteers
+     */
+    @Override
+    public AttributeValue transformFrom(List<Volunteer> input) {
+        if (input == null) {
+            return AttributeValue.builder().nul(true).build();
+        }
+        List<AttributeValue> items = input.stream()
+                .map(v -> AttributeValue.builder()
+                        .s(String.join(DELIMITER,
+                                v.getId(),
+                                v.getName(),
+                                v.getEmail(),
+                                v.getRsvpStatus()))
+                        .build())
+                .collect(Collectors.toList());
+        return AttributeValue.builder().l(items).build();
+    }
+
+    /**
+     * Converts a DynamoDB AttributeValue (List type) back to a list of volunteers.
+     *
+     * @param input the DynamoDB AttributeValue
+     * @return the deserialised list of volunteers
+     */
+    @Override
+    public List<Volunteer> transformTo(AttributeValue input) {
+        return input.l().stream().map(av -> {
+            String[] parts = av.s().split(DELIMITER_REGEX, 4);
+            Volunteer volunteer = new Volunteer();
+            volunteer.setId(parts[0]);
+            volunteer.setName(parts[1]);
+            volunteer.setEmail(parts[2]);
+            volunteer.setRsvpStatus(parts[3]);
+            return volunteer;
+        }).collect(Collectors.toList());
+    }
+
+    /** @return the enhanced type descriptor for {@code List<Volunteer>} */
+    @Override
+    public EnhancedType<List<Volunteer>> type() {
+        return EnhancedType.listOf(Volunteer.class);
+    }
+
+    /** @return the DynamoDB attribute type (List) */
+    @Override
+    public AttributeValueType attributeValueType() {
+        return AttributeValueType.L;
+    }
+}

--- a/Application/src/main/java/com/kenzie/appserver/security/SecurityConfig.java
+++ b/Application/src/main/java/com/kenzie/appserver/security/SecurityConfig.java
@@ -41,8 +41,9 @@ public class SecurityConfig {
                 .csrf(csrf -> csrf.disable())
                 .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        // public read access to campaigns and user profiles
+                        // public read access to campaigns, events, and user profiles
                         .requestMatchers(HttpMethod.GET, "/campaigns/**").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/events/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/users/**").permitAll()
                         // donations are public so supporters don't need an account (Stripe handles identity)
                         .requestMatchers(HttpMethod.POST, "/campaigns/*/donate").permitAll()

--- a/Application/src/main/java/com/kenzie/appserver/service/CampaignService.java
+++ b/Application/src/main/java/com/kenzie/appserver/service/CampaignService.java
@@ -8,6 +8,7 @@ import com.kenzie.appserver.repositories.CampaignDao;
 import com.kenzie.appserver.repositories.model.CampaignRecord;
 import com.kenzie.appserver.salesforce.SalesforceService;
 import com.kenzie.appserver.service.model.CampaignStatus;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
@@ -22,10 +23,12 @@ import java.util.UUID;
 public class CampaignService {
 
     private final CampaignDao campaignDao;
-    private final CacheStore cache;
+    private final CacheStore<CampaignRecord> cache;
     private final SalesforceService salesforceService;
 
-    public CampaignService(CampaignDao campaignDao, CacheStore cache, SalesforceService salesforceService) {
+    public CampaignService(CampaignDao campaignDao,
+                           @Qualifier("campaignCache") CacheStore<CampaignRecord> cache,
+                           SalesforceService salesforceService) {
         this.campaignDao = campaignDao;
         this.cache = cache;
         this.salesforceService = salesforceService;

--- a/Application/src/main/java/com/kenzie/appserver/service/FundraisingEventService.java
+++ b/Application/src/main/java/com/kenzie/appserver/service/FundraisingEventService.java
@@ -1,0 +1,420 @@
+package com.kenzie.appserver.service;
+
+import com.kenzie.appserver.config.CacheStore;
+import com.kenzie.appserver.controller.model.CreateEventRequest;
+import com.kenzie.appserver.controller.model.EventResponse;
+import com.kenzie.appserver.controller.model.EventUpdateRequest;
+import com.kenzie.appserver.controller.model.RsvpRequest;
+import com.kenzie.appserver.repositories.FundraisingEventDao;
+import com.kenzie.appserver.repositories.model.FundraisingEventRecord;
+import com.kenzie.appserver.service.model.EventStatus;
+import com.kenzie.appserver.service.model.RsvpStatus;
+import com.kenzie.appserver.service.model.Volunteer;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Business logic for fundraising event lifecycle: creation, updates,
+ * volunteer RSVP, waitlist promotion, and cancellation.
+ *
+ * <p>Cache key format: {@code "event:" + eventId}. This namespace avoids collisions
+ * with the campaign entries stored by {@link CampaignService} (plain IDs).
+ */
+@Service
+public class FundraisingEventService {
+
+    private static final String CACHE_PREFIX = "event:";
+
+    private final FundraisingEventDao eventDao;
+    private final CacheStore<FundraisingEventRecord> cache;
+
+    public FundraisingEventService(FundraisingEventDao eventDao,
+                                   @Qualifier("eventCache") CacheStore<FundraisingEventRecord> cache) {
+        this.eventDao = eventDao;
+        this.cache = cache;
+    }
+
+    // ── Reads ──────────────────────────────────────────────────────────────────
+
+    /**
+     * Returns the event with the given ID.
+     * Results are served from the in-memory cache when available.
+     *
+     * @param eventId the event ID
+     * @return the event response
+     * @throws ResponseStatusException 400 if ID is blank, 404 if not found
+     */
+    public EventResponse getEventById(String eventId) {
+        if (eventId == null || eventId.isBlank()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Event ID cannot be empty");
+        }
+        String cacheKey = CACHE_PREFIX + eventId;
+        Optional<FundraisingEventRecord> cached = cache.get(cacheKey);
+        if (cached != null) {
+            return cached.map(this::recordToResponse)
+                    .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Event not found"));
+        }
+        Optional<FundraisingEventRecord> record = eventDao.findById(eventId);
+        cache.add(cacheKey, record);
+        return record.map(this::recordToResponse)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Event not found"));
+    }
+
+    /**
+     * Returns all events. Performs a full DynamoDB table scan.
+     *
+     * @return list of all event responses
+     */
+    public List<EventResponse> getAllEvents() {
+        return eventDao.findAll().stream()
+                .map(this::recordToResponse)
+                .toList();
+    }
+
+    /**
+     * Returns all events for a given campaign.
+     *
+     * @param campaignId the campaign ID
+     * @return list of matching event responses
+     * @throws ResponseStatusException 400 if campaignId is blank
+     */
+    public List<EventResponse> getEventsByCampaign(String campaignId) {
+        if (campaignId == null || campaignId.isBlank()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Campaign ID cannot be empty");
+        }
+        return eventDao.findByCampaignId(campaignId).stream()
+                .map(this::recordToResponse)
+                .toList();
+    }
+
+    // ── Writes ─────────────────────────────────────────────────────────────────
+
+    /**
+     * Creates a new event in PLANNING status with an empty volunteer list.
+     *
+     * @param request the creation request
+     * @return the created event response
+     * @throws ResponseStatusException 400 if name or campaignId is blank,
+     *         organizer is null, or registrationDeadline is after eventDate
+     */
+    public EventResponse createEvent(CreateEventRequest request) {
+        if (request.getName() == null || request.getName().isBlank()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Event name is required");
+        }
+        if (request.getCampaignId() == null || request.getCampaignId().isBlank()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Campaign ID is required");
+        }
+        if (request.getOrganizer() == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Event must have an organizer");
+        }
+        if (request.getEventDate() != null && request.getRegistrationDeadline() != null
+                && request.getRegistrationDeadline().isAfter(request.getEventDate())) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    "Registration deadline must be on or before the event date");
+        }
+
+        FundraisingEventRecord record = new FundraisingEventRecord();
+        record.setId(UUID.randomUUID().toString());
+        record.setCampaignId(request.getCampaignId());
+        record.setName(request.getName());
+        record.setDescription(request.getDescription());
+        record.setLocation(request.getLocation());
+        record.setEventDate(request.getEventDate());
+        record.setRegistrationDeadline(request.getRegistrationDeadline());
+        record.setCapacity(request.getCapacity());
+        record.setOrganizer(request.getOrganizer());
+        record.setVolunteers(new ArrayList<>());
+        record.setStatus(EventStatus.PLANNING.name());
+        eventDao.save(record);
+
+        return recordToResponse(record);
+    }
+
+    /**
+     * Updates an event's mutable fields.
+     * Only the organizer (matched by JWT subject) may update.
+     * COMPLETED and CANCELLED events cannot be modified.
+     *
+     * @param request          the update payload
+     * @param requestingUserId the user ID from the authenticated JWT
+     * @return the updated event response
+     * @throws ResponseStatusException 404 if not found, 403 if not the organizer,
+     *         409 if the event is already completed or cancelled
+     */
+    public EventResponse updateEvent(EventUpdateRequest request, String requestingUserId) {
+        FundraisingEventRecord record = requireEvent(request.getId());
+        requireOrganizer(record, requestingUserId);
+        requireModifiable(record);
+
+        if (request.getEventDate() != null && request.getRegistrationDeadline() != null
+                && request.getRegistrationDeadline().isAfter(request.getEventDate())) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    "Registration deadline must be on or before the event date");
+        }
+
+        record.setName(request.getName());
+        record.setDescription(request.getDescription());
+        record.setLocation(request.getLocation());
+        record.setEventDate(request.getEventDate());
+        record.setRegistrationDeadline(request.getRegistrationDeadline());
+        record.setCapacity(request.getCapacity());
+        eventDao.save(record);
+        cache.evict(CACHE_PREFIX + record.getId());
+
+        return recordToResponse(record);
+    }
+
+    /**
+     * Moves an event from PLANNING to SCHEDULED, opening it for RSVPs.
+     * Only the organizer may publish.
+     *
+     * @param eventId          the event to publish
+     * @param requestingUserId the user ID from the authenticated JWT
+     * @return the updated event response
+     * @throws ResponseStatusException 404 if not found, 403 if not the organizer,
+     *         409 if the event is not in PLANNING status
+     */
+    public EventResponse publishEvent(String eventId, String requestingUserId) {
+        FundraisingEventRecord record = requireEvent(eventId);
+        requireOrganizer(record, requestingUserId);
+
+        if (!EventStatus.PLANNING.name().equals(record.getStatus())) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT,
+                    "Only events in PLANNING status can be published");
+        }
+
+        record.setStatus(EventStatus.SCHEDULED.name());
+        eventDao.save(record);
+        cache.evict(CACHE_PREFIX + eventId);
+
+        return recordToResponse(record);
+    }
+
+    /**
+     * Cancels a SCHEDULED or IN_PROGRESS event.
+     * Only the organizer may cancel.
+     *
+     * @param eventId          the event to cancel
+     * @param requestingUserId the user ID from the authenticated JWT
+     * @return the updated event response with CANCELLED status
+     * @throws ResponseStatusException 404 if not found, 403 if not the organizer,
+     *         409 if the event is already completed or cancelled
+     */
+    public EventResponse cancelEvent(String eventId, String requestingUserId) {
+        FundraisingEventRecord record = requireEvent(eventId);
+        requireOrganizer(record, requestingUserId);
+        requireModifiable(record);
+
+        record.setStatus(EventStatus.CANCELLED.name());
+        eventDao.save(record);
+        cache.evict(CACHE_PREFIX + eventId);
+
+        return recordToResponse(record);
+    }
+
+    /**
+     * Permanently deletes an event and evicts it from the cache.
+     * Only PLANNING-status events may be deleted; use cancel for scheduled events.
+     *
+     * @param eventId          the event to delete
+     * @param requestingUserId the user ID from the authenticated JWT
+     * @throws ResponseStatusException 400 if ID is blank, 404 if not found,
+     *         403 if not the organizer, 409 if the event is not in PLANNING status
+     */
+    public void deleteEvent(String eventId, String requestingUserId) {
+        if (eventId == null || eventId.isBlank()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Event ID cannot be empty");
+        }
+        FundraisingEventRecord record = requireEvent(eventId);
+        requireOrganizer(record, requestingUserId);
+
+        if (!EventStatus.PLANNING.name().equals(record.getStatus())) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT,
+                    "Only PLANNING events can be deleted — use cancel for scheduled events");
+        }
+
+        eventDao.deleteById(eventId);
+        cache.evict(CACHE_PREFIX + eventId);
+    }
+
+    // ── RSVP ──────────────────────────────────────────────────────────────────
+
+    /**
+     * Adds a volunteer RSVP to a SCHEDULED event.
+     *
+     * <ul>
+     *   <li>If capacity is unlimited or confirmed count is below capacity → CONFIRMED</li>
+     *   <li>Otherwise → WAITLISTED</li>
+     *   <li>If the volunteer already has an active RSVP → 409 Conflict</li>
+     * </ul>
+     *
+     * @param eventId the event to RSVP to
+     * @param request the volunteer details
+     * @return the updated event response
+     * @throws ResponseStatusException 404 if event not found,
+     *         409 if not SCHEDULED, past the deadline, or volunteer already registered
+     */
+    public EventResponse rsvp(String eventId, RsvpRequest request) {
+        FundraisingEventRecord record = requireEvent(eventId);
+
+        if (!EventStatus.SCHEDULED.name().equals(record.getStatus())) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT,
+                    "RSVPs are only accepted for SCHEDULED events");
+        }
+        if (record.getRegistrationDeadline() != null
+                && LocalDate.now().isAfter(record.getRegistrationDeadline())) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT,
+                    "The registration deadline has passed");
+        }
+
+        List<Volunteer> volunteers = mutableVolunteers(record);
+
+        // Reject duplicate active RSVPs
+        boolean alreadyRegistered = volunteers.stream()
+                .anyMatch(v -> v.getId().equals(request.getVolunteerId())
+                        && !RsvpStatus.CANCELLED.name().equals(v.getRsvpStatus()));
+        if (alreadyRegistered) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT,
+                    "Volunteer is already registered for this event");
+        }
+
+        long confirmedCount = volunteers.stream()
+                .filter(v -> RsvpStatus.CONFIRMED.name().equals(v.getRsvpStatus()))
+                .count();
+
+        String status = (record.getCapacity() == null || confirmedCount < record.getCapacity())
+                ? RsvpStatus.CONFIRMED.name()
+                : RsvpStatus.WAITLISTED.name();
+
+        Volunteer volunteer = new Volunteer(
+                request.getVolunteerId(),
+                request.getVolunteerName(),
+                request.getVolunteerEmail(),
+                status);
+        volunteers.add(volunteer);
+        record.setVolunteers(volunteers);
+        eventDao.save(record);
+        cache.evict(CACHE_PREFIX + eventId);
+
+        return recordToResponse(record);
+    }
+
+    /**
+     * Cancels a volunteer's RSVP.
+     * If a CONFIRMED volunteer cancels and there are WAITLISTED volunteers,
+     * the first waitlisted volunteer is automatically promoted to CONFIRMED.
+     * A volunteer can only cancel their own RSVP (JWT subject must match volunteerId).
+     *
+     * @param eventId          the event ID
+     * @param volunteerId      the volunteer's user ID
+     * @param requestingUserId the user ID from the authenticated JWT
+     * @return the updated event response
+     * @throws ResponseStatusException 404 if event not found or volunteer not found,
+     *         403 if the JWT subject does not match the volunteerId
+     */
+    public EventResponse cancelRsvp(String eventId, String volunteerId, String requestingUserId) {
+        if (!Objects.equals(requestingUserId, volunteerId)) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN,
+                    "You can only cancel your own RSVP");
+        }
+
+        FundraisingEventRecord record = requireEvent(eventId);
+        List<Volunteer> volunteers = mutableVolunteers(record);
+
+        Volunteer target = volunteers.stream()
+                .filter(v -> v.getId().equals(volunteerId)
+                        && !RsvpStatus.CANCELLED.name().equals(v.getRsvpStatus()))
+                .findFirst()
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,
+                        "Active RSVP not found for this volunteer"));
+
+        boolean wasConfirmed = RsvpStatus.CONFIRMED.name().equals(target.getRsvpStatus());
+        target.setRsvpStatus(RsvpStatus.CANCELLED.name());
+
+        // Promote first waitlisted volunteer when a confirmed spot opens
+        if (wasConfirmed) {
+            volunteers.stream()
+                    .filter(v -> RsvpStatus.WAITLISTED.name().equals(v.getRsvpStatus()))
+                    .findFirst()
+                    .ifPresent(v -> v.setRsvpStatus(RsvpStatus.CONFIRMED.name()));
+        }
+
+        record.setVolunteers(volunteers);
+        eventDao.save(record);
+        cache.evict(CACHE_PREFIX + eventId);
+
+        return recordToResponse(record);
+    }
+
+    // ── Helpers ────────────────────────────────────────────────────────────────
+
+    private FundraisingEventRecord requireEvent(String eventId) {
+        return eventDao.findById(eventId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Event not found"));
+    }
+
+    private void requireOrganizer(FundraisingEventRecord record, String requestingUserId) {
+        if (record.getOrganizer() == null
+                || !Objects.equals(requestingUserId, record.getOrganizer().getId())) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN,
+                    "Only the event organizer can perform this action");
+        }
+    }
+
+    private void requireModifiable(FundraisingEventRecord record) {
+        String status = record.getStatus();
+        if (EventStatus.COMPLETED.name().equals(status) || EventStatus.CANCELLED.name().equals(status)) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT,
+                    "Cannot modify a COMPLETED or CANCELLED event");
+        }
+    }
+
+    /** Returns a mutable copy of the volunteer list (never null). */
+    private List<Volunteer> mutableVolunteers(FundraisingEventRecord record) {
+        List<Volunteer> existing = record.getVolunteers();
+        return existing == null ? new ArrayList<>() : new ArrayList<>(existing);
+    }
+
+    private EventResponse recordToResponse(FundraisingEventRecord record) {
+        List<Volunteer> volunteers = record.getVolunteers() != null
+                ? record.getVolunteers() : List.of();
+
+        long confirmed = volunteers.stream()
+                .filter(v -> RsvpStatus.CONFIRMED.name().equals(v.getRsvpStatus()))
+                .count();
+        long waitlisted = volunteers.stream()
+                .filter(v -> RsvpStatus.WAITLISTED.name().equals(v.getRsvpStatus()))
+                .count();
+
+        EventResponse response = new EventResponse();
+        response.setId(record.getId());
+        response.setCampaignId(record.getCampaignId());
+        response.setName(record.getName());
+        response.setDescription(record.getDescription());
+        response.setLocation(record.getLocation());
+        response.setEventDate(record.getEventDate());
+        response.setRegistrationDeadline(record.getRegistrationDeadline());
+        response.setCapacity(record.getCapacity());
+        response.setOrganizer(record.getOrganizer());
+        response.setVolunteers(volunteers);
+        response.setStatus(record.getStatus());
+        response.setConfirmedCount((int) confirmed);
+        response.setWaitlistedCount((int) waitlisted);
+
+        if (record.getCapacity() != null) {
+            int remaining = Math.max(0, record.getCapacity() - (int) confirmed);
+            response.setSpotsRemaining(remaining);
+        }
+
+        return response;
+    }
+}

--- a/Application/src/main/java/com/kenzie/appserver/service/model/EventStatus.java
+++ b/Application/src/main/java/com/kenzie/appserver/service/model/EventStatus.java
@@ -1,0 +1,32 @@
+package com.kenzie.appserver.service.model;
+
+/**
+ * Lifecycle states for a {@link com.kenzie.appserver.repositories.model.FundraisingEventRecord}.
+ *
+ * <p>Valid transitions:
+ * <pre>
+ *   PLANNING → SCHEDULED → IN_PROGRESS → COMPLETED
+ *                       ↘                ↗
+ *                        CANCELLED ←────
+ * </pre>
+ * The organiser moves the event from PLANNING to SCHEDULED once the details are confirmed;
+ * a scheduled job or manual action moves it to IN_PROGRESS / COMPLETED based on dates.
+ * CANCELLED may be set from SCHEDULED or IN_PROGRESS.
+ */
+public enum EventStatus {
+
+    /** Event is being planned; volunteers cannot yet RSVP. */
+    PLANNING,
+
+    /** Event is confirmed; volunteers may submit RSVPs up to the registration deadline. */
+    SCHEDULED,
+
+    /** Event is currently in progress; new RSVPs are no longer accepted. */
+    IN_PROGRESS,
+
+    /** Event has concluded successfully. */
+    COMPLETED,
+
+    /** Event was cancelled before or during execution. */
+    CANCELLED
+}

--- a/Application/src/main/java/com/kenzie/appserver/service/model/RsvpStatus.java
+++ b/Application/src/main/java/com/kenzie/appserver/service/model/RsvpStatus.java
@@ -1,0 +1,22 @@
+package com.kenzie.appserver.service.model;
+
+/**
+ * RSVP state for a volunteer on a fundraising event.
+ *
+ * <ul>
+ *   <li>{@link #CONFIRMED} — volunteer has a guaranteed spot</li>
+ *   <li>{@link #WAITLISTED} — volunteer registered after capacity was reached</li>
+ *   <li>{@link #CANCELLED} — volunteer cancelled their own RSVP</li>
+ * </ul>
+ */
+public enum RsvpStatus {
+
+    /** Volunteer has a confirmed spot at the event. */
+    CONFIRMED,
+
+    /** Volunteer is on the waitlist due to capacity limits. */
+    WAITLISTED,
+
+    /** Volunteer cancelled their RSVP. */
+    CANCELLED
+}

--- a/Application/src/main/java/com/kenzie/appserver/service/model/Volunteer.java
+++ b/Application/src/main/java/com/kenzie/appserver/service/model/Volunteer.java
@@ -1,0 +1,45 @@
+package com.kenzie.appserver.service.model;
+
+/**
+ * Represents a volunteer who has RSVPed to a {@link com.kenzie.appserver.repositories.model.FundraisingEventRecord}.
+ *
+ * <p>Stored as a delimited string via
+ * {@link com.kenzie.appserver.repositories.model.VolunteerTypeConverter}:
+ * {@code "id|name|email|rsvpStatus"}.
+ */
+public class Volunteer {
+
+    private String id;
+    private String name;
+    private String email;
+    private String rsvpStatus; // RsvpStatus.name()
+
+    public Volunteer() {}
+
+    public Volunteer(String id, String name, String email, String rsvpStatus) {
+        this.id = id;
+        this.name = name;
+        this.email = email;
+        this.rsvpStatus = rsvpStatus;
+    }
+
+    /** @return the volunteer's user ID */
+    public String getId() { return id; }
+    /** @param id the volunteer's user ID */
+    public void setId(String id) { this.id = id; }
+
+    /** @return the volunteer's display name */
+    public String getName() { return name; }
+    /** @param name the volunteer's display name */
+    public void setName(String name) { this.name = name; }
+
+    /** @return the volunteer's email address */
+    public String getEmail() { return email; }
+    /** @param email the volunteer's email address */
+    public void setEmail(String email) { this.email = email; }
+
+    /** @return the RSVP status name (see {@link RsvpStatus}) */
+    public String getRsvpStatus() { return rsvpStatus; }
+    /** @param rsvpStatus the RSVP status name */
+    public void setRsvpStatus(String rsvpStatus) { this.rsvpStatus = rsvpStatus; }
+}

--- a/Frontend/src/api/eventApi.js
+++ b/Frontend/src/api/eventApi.js
@@ -1,0 +1,74 @@
+import client from './client.js';
+
+/** @returns {Promise<import('../types').FundraisingEvent[]>} */
+export const getAllEvents = async () => {
+  const { data } = await client.get('/events/all');
+  return data;
+};
+
+/** @param {string} id */
+export const getEventById = async (id) => {
+  const { data } = await client.get(`/events/${id}`);
+  return data;
+};
+
+/** @param {string} campaignId */
+export const getEventsByCampaign = async (campaignId) => {
+  const { data } = await client.get(`/events/campaign/${campaignId}`);
+  return data;
+};
+
+/**
+ * @param {object} payload - CreateEventRequest shape
+ * @returns {Promise<import('../types').FundraisingEvent>}
+ */
+export const createEvent = async (payload) => {
+  const { data } = await client.post('/events', payload);
+  return data;
+};
+
+/**
+ * @param {string} eventId
+ * @param {object} payload - EventUpdateRequest shape
+ */
+export const updateEvent = async (eventId, payload) => {
+  const { data } = await client.put(`/events/${eventId}`, payload);
+  return data;
+};
+
+/** @param {string} eventId */
+export const publishEvent = async (eventId) => {
+  const { data } = await client.post(`/events/${eventId}/publish`);
+  return data;
+};
+
+/** @param {string} eventId */
+export const cancelEvent = async (eventId) => {
+  const { data } = await client.post(`/events/${eventId}/cancel`);
+  return data;
+};
+
+/** @param {string} eventId */
+export const deleteEvent = async (eventId) => {
+  await client.delete(`/events/${eventId}`);
+};
+
+/**
+ * Submit a volunteer RSVP.
+ * @param {string} eventId
+ * @param {{ volunteerId: string, volunteerName: string, volunteerEmail: string }} payload
+ */
+export const rsvpToEvent = async (eventId, payload) => {
+  const { data } = await client.post(`/events/${eventId}/rsvp`, payload);
+  return data;
+};
+
+/**
+ * Cancel a volunteer's own RSVP.
+ * @param {string} eventId
+ * @param {string} volunteerId
+ */
+export const cancelRsvp = async (eventId, volunteerId) => {
+  const { data } = await client.delete(`/events/${eventId}/rsvp/${volunteerId}`);
+  return data;
+};

--- a/Frontend/src/pages/CalendarPage/CalendarPage.jsx
+++ b/Frontend/src/pages/CalendarPage/CalendarPage.jsx
@@ -1,16 +1,99 @@
+import { Link } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+import { getAllEvents } from '../../api/eventApi.js';
 import styles from './CalendarPage.module.css';
 
-/**
- * Placeholder — calendar view will display FundraisingEvent deadlines
- * and volunteer shift slots once the event entity is implemented (Phase 3).
- */
+const monthLabel = (iso) =>
+  new Intl.DateTimeFormat('en-US', { month: 'long', year: 'numeric' }).format(
+    new Date(iso + 'T12:00:00')
+  );
+
+const dayLabel = (iso) =>
+  new Intl.DateTimeFormat('en-US', { weekday: 'short', month: 'short', day: 'numeric' }).format(
+    new Date(iso + 'T12:00:00')
+  );
+
+const STATUS_DOT = {
+  PLANNING: styles.dotPlanning,
+  SCHEDULED: styles.dotScheduled,
+  IN_PROGRESS: styles.dotInProgress,
+  COMPLETED: styles.dotCompleted,
+  CANCELLED: styles.dotCancelled,
+};
+
+/** Group an array by a string key derived from each item. */
+function groupBy(items, keyFn) {
+  return items.reduce((acc, item) => {
+    const key = keyFn(item);
+    if (!acc[key]) acc[key] = [];
+    acc[key].push(item);
+    return acc;
+  }, {});
+}
+
 export default function CalendarPage() {
+  const {
+    data: events,
+    isLoading,
+    isError,
+  } = useQuery({
+    queryKey: ['events'],
+    queryFn: getAllEvents,
+  });
+
+  if (isLoading) return <p className={styles.state}>Loading calendar…</p>;
+  if (isError) return <p className={styles.stateError}>Failed to load events. Please try again.</p>;
+
+  const active = (events ?? []).filter((e) => e.status !== 'CANCELLED');
+
+  if (!active.length)
+    return (
+      <div>
+        <h1 className={styles.heading}>Calendar</h1>
+        <p className={styles.state}>No upcoming events scheduled yet.</p>
+      </div>
+    );
+
+  // Sort by eventDate ascending, then group by "Month Year"
+  const sorted = [...active].sort((a, b) => (a.eventDate ?? '').localeCompare(b.eventDate ?? ''));
+  const grouped = groupBy(sorted, (e) => (e.eventDate ? monthLabel(e.eventDate) : 'Undated'));
+
   return (
     <div>
       <h1 className={styles.heading}>Calendar</h1>
-      <p className={styles.placeholder}>
-        Your campaign deadlines and volunteer events will appear here in Phase 3.
-      </p>
+
+      {Object.entries(grouped).map(([month, monthEvents]) => (
+        <section key={month} className={styles.month}>
+          <h2 className={styles.monthHeading}>{month}</h2>
+          <ul className={styles.list}>
+            {monthEvents.map((event) => (
+              <li key={event.id} className={styles.item}>
+                <div className={styles.dateBadge}>
+                  {event.eventDate ? dayLabel(event.eventDate) : '—'}
+                </div>
+                <div className={styles.itemBody}>
+                  <div className={styles.itemHeader}>
+                    <span className={styles.eventName}>{event.name}</span>
+                    <span className={`${styles.dot} ${STATUS_DOT[event.status] ?? ''}`} />
+                  </div>
+                  {event.location && <span className={styles.location}>{event.location}</span>}
+                  <div className={styles.itemFooter}>
+                    <span className={styles.rsvpCount}>
+                      {event.confirmedCount} confirmed
+                      {event.waitlistedCount > 0 && ` · ${event.waitlistedCount} waitlisted`}
+                    </span>
+                    {event.status === 'SCHEDULED' && (
+                      <Link to="/events" className={styles.rsvpLink}>
+                        RSVP →
+                      </Link>
+                    )}
+                  </div>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </section>
+      ))}
     </div>
   );
 }

--- a/Frontend/src/pages/CalendarPage/CalendarPage.module.css
+++ b/Frontend/src/pages/CalendarPage/CalendarPage.module.css
@@ -1,10 +1,110 @@
 .heading {
   font-size: 1.75rem;
   font-weight: 700;
-  margin-bottom: 1rem;
+  margin-bottom: 1.5rem;
 }
-.placeholder {
+.state {
   color: var(--color-text-muted);
+}
+.stateError {
+  color: var(--color-error);
+}
+.month {
+  margin-bottom: 2rem;
+}
+.monthHeading {
+  font-size: 1rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--color-text-muted);
+  margin-bottom: 0.75rem;
+  padding-bottom: 0.375rem;
+  border-bottom: 1px solid var(--color-border);
+}
+.list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.625rem;
+  padding: 0;
+}
+.item {
+  display: flex;
+  gap: 1rem;
+  background-color: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: 0.875rem 1.125rem;
+}
+.dateBadge {
+  flex-shrink: 0;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--color-text-muted);
+  min-width: 9rem;
+  padding-top: 0.0625rem;
+}
+.itemBody {
+  flex: 1;
+  min-width: 0;
+}
+.itemHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.25rem;
+}
+.eventName {
+  font-weight: 600;
   font-size: 0.9375rem;
-  line-height: 1.6;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.dot {
+  flex-shrink: 0;
+  width: 0.625rem;
+  height: 0.625rem;
+  border-radius: 50%;
+  background-color: var(--color-border);
+}
+.dotPlanning {
+  background-color: #94a3b8;
+}
+.dotScheduled {
+  background-color: #10b981;
+}
+.dotInProgress {
+  background-color: #3b82f6;
+}
+.dotCompleted {
+  background-color: #8b5cf6;
+}
+.dotCancelled {
+  background-color: #ef4444;
+}
+.location {
+  font-size: 0.8125rem;
+  color: var(--color-text-muted);
+  display: block;
+  margin-bottom: 0.375rem;
+}
+.itemFooter {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+.rsvpCount {
+  font-size: 0.8125rem;
+  color: var(--color-text-muted);
+}
+.rsvpLink {
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--color-primary);
+  text-decoration: none;
+}
+.rsvpLink:hover {
+  text-decoration: underline;
 }

--- a/Frontend/src/pages/EventsPage/EventsPage.jsx
+++ b/Frontend/src/pages/EventsPage/EventsPage.jsx
@@ -1,17 +1,187 @@
+import { useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { getAllEvents, rsvpToEvent, cancelRsvp } from '../../api/eventApi.js';
+import { useAuth } from '../../hooks/useAuth.js';
 import styles from './EventsPage.module.css';
 
-/**
- * Placeholder — FundraisingEvent entity is Phase 3 backend work.
- * Once the /events endpoints exist, this page will use TanStack Query
- * to fetch and display events the authenticated user is registered for.
- */
+const STATUS_LABEL = {
+  PLANNING: 'Planning',
+  SCHEDULED: 'Open for RSVPs',
+  IN_PROGRESS: 'In Progress',
+  COMPLETED: 'Completed',
+  CANCELLED: 'Cancelled',
+};
+
+const formatDate = (iso) =>
+  iso
+    ? new Intl.DateTimeFormat('en-US', { month: 'short', day: 'numeric', year: 'numeric' }).format(
+        new Date(iso + 'T12:00:00')
+      )
+    : '—';
+
 export default function EventsPage() {
+  const { isAuthenticated, userId } = useAuth();
+  const queryClient = useQueryClient();
+  const [rsvpError, setRsvpError] = useState({});
+
+  const {
+    data: events,
+    isLoading,
+    isError,
+  } = useQuery({
+    queryKey: ['events'],
+    queryFn: getAllEvents,
+  });
+
+  const rsvpMutation = useMutation({
+    mutationFn: ({ eventId, payload }) => rsvpToEvent(eventId, payload),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['events'] }),
+    onError: (err, variables) => {
+      const msg = err.response?.data?.message ?? 'Failed to RSVP. Please try again.';
+      setRsvpError((prev) => ({ ...prev, [variables.eventId]: msg }));
+    },
+  });
+
+  const cancelMutation = useMutation({
+    mutationFn: ({ eventId, volunteerId }) => cancelRsvp(eventId, volunteerId),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['events'] }),
+    onError: (err, variables) => {
+      const msg = err.response?.data?.message ?? 'Failed to cancel RSVP. Please try again.';
+      setRsvpError((prev) => ({ ...prev, [variables.eventId]: msg }));
+    },
+  });
+
+  if (isLoading) return <p className={styles.state}>Loading events…</p>;
+  if (isError) return <p className={styles.stateError}>Failed to load events. Please try again.</p>;
+  if (!events?.length)
+    return (
+      <div>
+        <h1 className={styles.heading}>Volunteer Events</h1>
+        <p className={styles.state}>No events scheduled yet.</p>
+      </div>
+    );
+
+  const scheduled = events.filter((e) => e.status === 'SCHEDULED');
+  const other = events.filter((e) => e.status !== 'SCHEDULED');
+
+  const myRsvp = (event) =>
+    event.volunteers?.find((v) => v.id === userId && v.rsvpStatus !== 'CANCELLED');
+
+  const handleRsvp = (event) => {
+    setRsvpError((prev) => ({ ...prev, [event.id]: null }));
+    // In a real app the name/email come from the user's profile.
+    // For now we pull them from the JWT claims stored alongside the token.
+    const name = localStorage.getItem('gw_userName') ?? 'Volunteer';
+    const email = localStorage.getItem('gw_userEmail') ?? '';
+    rsvpMutation.mutate({
+      eventId: event.id,
+      payload: { volunteerId: userId, volunteerName: name, volunteerEmail: email },
+    });
+  };
+
+  const handleCancelRsvp = (event) => {
+    setRsvpError((prev) => ({ ...prev, [event.id]: null }));
+    cancelMutation.mutate({ eventId: event.id, volunteerId: userId });
+  };
+
+  const renderEvent = (event) => {
+    const existing = myRsvp(event);
+    const isScheduled = event.status === 'SCHEDULED';
+    const isBusy =
+      (rsvpMutation.isPending && rsvpMutation.variables?.eventId === event.id) ||
+      (cancelMutation.isPending && cancelMutation.variables?.eventId === event.id);
+
+    return (
+      <li key={event.id} className={styles.card}>
+        <div className={styles.cardHeader}>
+          <span className={`${styles.status} ${styles[event.status?.toLowerCase()]}`}>
+            {STATUS_LABEL[event.status] ?? event.status}
+          </span>
+          {event.spotsRemaining != null && (
+            <span className={styles.spots}>
+              {event.spotsRemaining === 0
+                ? 'Fully booked'
+                : `${event.spotsRemaining} spot${event.spotsRemaining === 1 ? '' : 's'} left`}
+            </span>
+          )}
+        </div>
+
+        <h2 className={styles.cardTitle}>{event.name}</h2>
+        {event.description && <p className={styles.cardDesc}>{event.description}</p>}
+
+        <dl className={styles.meta}>
+          {event.location && (
+            <>
+              <dt>Location</dt>
+              <dd>{event.location}</dd>
+            </>
+          )}
+          <dt>Date</dt>
+          <dd>{formatDate(event.eventDate)}</dd>
+          <dt>RSVP by</dt>
+          <dd>{formatDate(event.registrationDeadline)}</dd>
+          <dt>Volunteers</dt>
+          <dd>
+            {event.confirmedCount} confirmed
+            {event.waitlistedCount > 0 && ` · ${event.waitlistedCount} waitlisted`}
+          </dd>
+        </dl>
+
+        {rsvpError[event.id] && <p className={styles.error}>{rsvpError[event.id]}</p>}
+
+        {isAuthenticated && isScheduled && (
+          <div className={styles.actions}>
+            {existing ? (
+              <>
+                <span className={styles.rsvpBadge}>
+                  {existing.rsvpStatus === 'CONFIRMED' ? '✓ Confirmed' : '⏳ Waitlisted'}
+                </span>
+                <button
+                  className={styles.cancelBtn}
+                  onClick={() => handleCancelRsvp(event)}
+                  disabled={isBusy}
+                >
+                  {isBusy ? 'Cancelling…' : 'Cancel RSVP'}
+                </button>
+              </>
+            ) : (
+              <button
+                className={styles.rsvpBtn}
+                onClick={() => handleRsvp(event)}
+                disabled={isBusy}
+              >
+                {isBusy ? 'Submitting…' : 'RSVP'}
+              </button>
+            )}
+          </div>
+        )}
+
+        {!isAuthenticated && isScheduled && (
+          <p className={styles.signInPrompt}>
+            <a href="/login">Sign in</a> to RSVP for this event.
+          </p>
+        )}
+      </li>
+    );
+  };
+
   return (
     <div>
-      <h1 className={styles.heading}>Events</h1>
-      <p className={styles.placeholder}>
-        Volunteer events and RSVPs are coming in Phase 3. Check back soon!
-      </p>
+      <h1 className={styles.heading}>Volunteer Events</h1>
+
+      {scheduled.length > 0 && (
+        <section>
+          <h2 className={styles.sectionHeading}>Open for RSVPs</h2>
+          <ul className={styles.list}>{scheduled.map(renderEvent)}</ul>
+        </section>
+      )}
+
+      {other.length > 0 && (
+        <section className={styles.otherSection}>
+          <h2 className={styles.sectionHeading}>All Events</h2>
+          <ul className={styles.list}>{other.map(renderEvent)}</ul>
+        </section>
+      )}
     </div>
   );
 }

--- a/Frontend/src/pages/EventsPage/EventsPage.module.css
+++ b/Frontend/src/pages/EventsPage/EventsPage.module.css
@@ -1,10 +1,161 @@
 .heading {
   font-size: 1.75rem;
   font-weight: 700;
+  margin-bottom: 1.5rem;
+}
+.sectionHeading {
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 0.875rem;
+}
+.state {
+  color: var(--color-text-muted);
+}
+.stateError {
+  color: var(--color-error);
+}
+.list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin-bottom: 0;
+  padding: 0;
+}
+.otherSection {
+  margin-top: 2rem;
+}
+.card {
+  background-color: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: 1.25rem 1.5rem;
+}
+.cardHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.5rem;
+}
+.status {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 0.2rem 0.6rem;
+  border-radius: var(--radius-sm, 4px);
+  background-color: var(--color-border);
+  color: var(--color-text-muted);
+}
+.status.scheduled {
+  background-color: #d1fae5;
+  color: #065f46;
+}
+.status.in_progress {
+  background-color: #dbeafe;
+  color: #1e40af;
+}
+.status.completed {
+  background-color: #ede9fe;
+  color: #5b21b6;
+}
+.status.cancelled {
+  background-color: #fee2e2;
+  color: #991b1b;
+}
+.spots {
+  font-size: 0.8125rem;
+  color: var(--color-text-muted);
+}
+.cardTitle {
+  font-size: 1.0625rem;
+  font-weight: 600;
+  margin-bottom: 0.375rem;
+}
+.cardDesc {
+  font-size: 0.875rem;
+  color: var(--color-text-muted);
+  line-height: 1.5;
+  margin-bottom: 0.875rem;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+.meta {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 0.2rem 1rem;
+  font-size: 0.8125rem;
   margin-bottom: 1rem;
 }
-.placeholder {
+.meta dt {
   color: var(--color-text-muted);
-  font-size: 0.9375rem;
-  line-height: 1.6;
+  font-weight: 500;
+}
+.meta dd {
+  margin: 0;
+}
+.actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+.rsvpBtn {
+  padding: 0.5rem 1.25rem;
+  background-color: var(--color-primary);
+  color: #fff;
+  border: none;
+  border-radius: var(--radius-md);
+  font-size: 0.875rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: opacity 0.15s;
+}
+.rsvpBtn:hover:not(:disabled) {
+  opacity: 0.88;
+}
+.rsvpBtn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+.rsvpBadge {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--color-primary);
+}
+.cancelBtn {
+  padding: 0.4rem 0.875rem;
+  background: transparent;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  font-size: 0.8125rem;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  transition:
+    border-color 0.15s,
+    color 0.15s;
+}
+.cancelBtn:hover:not(:disabled) {
+  border-color: var(--color-error);
+  color: var(--color-error);
+}
+.cancelBtn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+.error {
+  font-size: 0.8125rem;
+  color: var(--color-error);
+  margin-bottom: 0.5rem;
+}
+.signInPrompt {
+  font-size: 0.875rem;
+  color: var(--color-text-muted);
+}
+.signInPrompt a {
+  color: var(--color-primary);
 }

--- a/FundraisingEventsTable.yml
+++ b/FundraisingEventsTable.yml
@@ -1,0 +1,29 @@
+Resources:
+  FundraisingEventsTable:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      AttributeDefinitions:
+        - AttributeName: "id"
+          AttributeType: "S"
+        - AttributeName: "campaignId"
+          AttributeType: "S"
+      KeySchema:
+        - AttributeName: "id"
+          KeyType: "HASH"
+      GlobalSecondaryIndexes:
+        - IndexName: "CampaignIdIndex"
+          KeySchema:
+            - AttributeName: "campaignId"
+              KeyType: "HASH"
+          Projection:
+            ProjectionType: ALL
+      BillingMode: PAY_PER_REQUEST
+      PointInTimeRecoverySpecification:
+        PointInTimeRecoveryEnabled: false
+      TableName: "FundraisingEvents"
+
+# Deploy:
+#   aws cloudformation create-stack \
+#     --stack-name fundraising-events \
+#     --template-body file://FundraisingEventsTable.yml \
+#     --capabilities CAPABILITY_IAM


### PR DESCRIPTION
## Summary

- **`EventStatus` / `RsvpStatus` / `Volunteer`** — new service-layer models
- **`VolunteerTypeConverter`** — pipe-delimited DynamoDB List serialiser (avoids the 'x' ambiguity used by `SupporterTypeConverter`)
- **`FundraisingEventRecord`** — `@DynamoDbBean` with `id` partition key; embeds `User organizer` via `UserTypeConverter` and `List<Volunteer>` via `VolunteerTypeConverter`
- **`FundraisingEventDao`** — Enhanced Client CRUD + `findByCampaignId` (client-side filter; GSI migration path documented)
- **`FundraisingEventService`** — full lifecycle: create → publish → update → cancel/delete; RSVP with capacity enforcement and automatic waitlist promotion on cancellation; organizer ownership enforced via JWT subject
- **`FundraisingEventController`** — REST under `/events`; public GETs, JWT-guarded writes
- **`CacheStore<T>`** — generalised from `CacheStore` to support typed beans; `CampaignService` now injects `@Qualifier("campaignCache")`, `FundraisingEventService` injects `@Qualifier("eventCache")`
- **`SecurityConfig`** — added `GET /events/**` to the public allowlist
- **`FundraisingEventsTable.yml`** — CloudFormation table definition with `CampaignIdIndex` GSI
- **`eventApi.js`** — full API module (getAllEvents, getEventsByCampaign, create/update/publish/cancel/delete, rsvpToEvent, cancelRsvp)
- **`EventsPage`** — live event list: SCHEDULED events show RSVP / cancel buttons, spots-remaining counter, waitlist badge, sign-in prompt for unauthenticated users
- **`CalendarPage`** — month-grouped timeline view with coloured status dots and "RSVP →" links to EventsPage

## API surface

| Method | Path | Auth | Description |
|--------|------|------|-------------|
| GET | `/events/{id}` | public | Get event by ID |
| GET | `/events/all` | public | All events (table scan) |
| GET | `/events/campaign/{campaignId}` | public | Events for a campaign |
| POST | `/events` | JWT | Create event (PLANNING) |
| PUT | `/events/{id}` | JWT + organizer | Update mutable fields |
| POST | `/events/{id}/publish` | JWT + organizer | PLANNING → SCHEDULED |
| POST | `/events/{id}/cancel` | JWT + organizer | Cancel event |
| DELETE | `/events/{id}` | JWT + organizer | Delete (PLANNING only) |
| POST | `/events/{id}/rsvp` | JWT | Submit RSVP (CONFIRMED or WAITLISTED) |
| DELETE | `/events/{id}/rsvp/{volunteerId}` | JWT + self | Cancel own RSVP; promotes waitlisted |

## Test plan

- [ ] `./gradlew :Application:compileJava :Application:test` passes
- [ ] `npm run lint -- --max-warnings=0` passes
- [ ] `npm run format:check` passes
- [ ] CI (`build-and-test` + `frontend-lint`) both green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added fundraising event management with create, update, publish, and cancel capabilities
  * Added volunteer RSVP system for event registration
  * Added event discovery features including calendar view and filterable events page
  * Enabled public access to event endpoints for event browsing

* **Refactor**
  * Updated cache system to support generic record types, improving flexibility for multiple cached entities

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/staceySpears/generositywell-fundraising-platform/pull/16)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->