### PR TITLE
feat: append-only AuditLog with dual GSIs (Phase 3 compliance foundation)

### DIFF
--- a/Application/src/main/java/com/kenzie/appserver/controller/CampaignController.java
+++ b/Application/src/main/java/com/kenzie/appserver/controller/CampaignController.java
@@ -131,8 +131,10 @@ public class CampaignController {
      * @return 204 on success, 400 if ID is blank, 404 if not found
      */
     @DeleteMapping("/{campaignId}")
-    public ResponseEntity<Void> deleteCampaignById(@PathVariable("campaignId") String campaignId) {
-        campaignService.deleteCampaign(campaignId);
+    public ResponseEntity<Void> deleteCampaignById(
+            @PathVariable("campaignId") String campaignId,
+            Authentication authentication) {
+        campaignService.deleteCampaign(campaignId, authentication.getName());
         return ResponseEntity.noContent().build();
     }
 

--- a/Application/src/main/java/com/kenzie/appserver/repositories/AuditLogDao.java
+++ b/Application/src/main/java/com/kenzie/appserver/repositories/AuditLogDao.java
@@ -1,0 +1,97 @@
+package com.kenzie.appserver.repositories;
+
+import com.kenzie.appserver.repositories.model.AuditLogRecord;
+import org.springframework.stereotype.Repository;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbIndex;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
+import software.amazon.awssdk.enhanced.dynamodb.Key;
+import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
+import software.amazon.awssdk.enhanced.dynamodb.model.QueryConditional;
+import software.amazon.awssdk.enhanced.dynamodb.model.QueryEnhancedRequest;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Append-only DynamoDB persistence layer for {@link AuditLogRecord}.
+ *
+ * <p><strong>Immutability contract:</strong> this DAO intentionally exposes no
+ * {@code delete} or {@code update} method. Audit records must never be modified
+ * after they are written.
+ *
+ * <p>Both GSI queries return results in ascending timestamp order (oldest first).
+ * To get the most recent events, reverse the returned list or use the
+ * {@code scanIndexForward(false)} variant if you add a descending helper later.
+ */
+@Repository
+public class AuditLogDao {
+
+    private static final String TABLE_NAME = "AuditLog";
+
+    private final DynamoDbTable<AuditLogRecord> auditTable;
+    private final DynamoDbIndex<AuditLogRecord> entityHistoryIndex;
+    private final DynamoDbIndex<AuditLogRecord> actorHistoryIndex;
+
+    public AuditLogDao(DynamoDbEnhancedClient enhancedClient) {
+        this.auditTable = enhancedClient.table(TABLE_NAME,
+                TableSchema.fromBean(AuditLogRecord.class));
+        this.entityHistoryIndex = auditTable.index(AuditLogRecord.ENTITY_HISTORY_INDEX);
+        this.actorHistoryIndex = auditTable.index(AuditLogRecord.ACTOR_HISTORY_INDEX);
+    }
+
+    /**
+     * Appends a new audit record. This is the only write operation this DAO exposes.
+     *
+     * @param record the record to persist
+     */
+    public void save(AuditLogRecord record) {
+        auditTable.putItem(record);
+    }
+
+    /**
+     * Returns all audit events for a specific entity, ordered by timestamp ascending.
+     * Uses the {@value AuditLogRecord#ENTITY_HISTORY_INDEX} GSI.
+     *
+     * @param entityId the entity ID (campaign ID, event ID, etc.)
+     * @return list of matching audit records, oldest first
+     */
+    public List<AuditLogRecord> findByEntityId(String entityId) {
+        QueryConditional condition = QueryConditional.keyEqualTo(
+                Key.builder().partitionValue(entityId).build());
+
+        return entityHistoryIndex
+                .query(QueryEnhancedRequest.builder()
+                        .queryConditional(condition)
+                        .scanIndexForward(true)
+                        .build())
+                .stream()
+                .flatMap(page -> page.items().stream())
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Returns all audit events triggered by a specific user, ordered by timestamp ascending.
+     * Uses the {@value AuditLogRecord#ACTOR_HISTORY_INDEX} GSI.
+     *
+     * <p>This is the primary data source for the user Dashboard and the Salesforce
+     * 360-degree supporter profile — it captures donations, RSVPs, campaign creation,
+     * and every other action the user has taken across the entire platform.
+     *
+     * @param actorId the user ID
+     * @return list of matching audit records, oldest first
+     */
+    public List<AuditLogRecord> findByActorId(String actorId) {
+        QueryConditional condition = QueryConditional.keyEqualTo(
+                Key.builder().partitionValue(actorId).build());
+
+        return actorHistoryIndex
+                .query(QueryEnhancedRequest.builder()
+                        .queryConditional(condition)
+                        .scanIndexForward(true)
+                        .build())
+                .stream()
+                .flatMap(page -> page.items().stream())
+                .collect(Collectors.toList());
+    }
+}

--- a/Application/src/main/java/com/kenzie/appserver/repositories/model/AuditLogRecord.java
+++ b/Application/src/main/java/com/kenzie/appserver/repositories/model/AuditLogRecord.java
@@ -1,0 +1,100 @@
+package com.kenzie.appserver.repositories.model;
+
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbSecondaryPartitionKey;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbSecondarySortKey;
+
+import java.time.Instant;
+
+/**
+ * Append-only DynamoDB record representing a single audited event.
+ *
+ * <h3>Table design</h3>
+ * <ul>
+ *   <li>Partition key: {@code logId} (UUID) — prevents hot partitions on busy entities</li>
+ *   <li>GSI {@value #ENTITY_HISTORY_INDEX}: {@code entityId} PK + {@code timestamp} SK —
+ *       query "all events for Campaign X, newest first"</li>
+ *   <li>GSI {@value #ACTOR_HISTORY_INDEX}: {@code actorId} PK + {@code timestamp} SK —
+ *       query "everything user Y has ever done" for the Dashboard and Salesforce 360 profile</li>
+ * </ul>
+ *
+ * <h3>Timestamp storage</h3>
+ * {@link Instant} is serialised by the Enhanced Client as an ISO-8601 string
+ * (e.g. {@code "2026-05-09T12:34:56.789Z"}), which sorts correctly as a DynamoDB
+ * sort-key attribute of type {@code S} — no epoch-millisecond workaround needed.
+ *
+ * <h3>Immutability contract</h3>
+ * Records must never be updated or deleted. The {@code AuditLogDao} exposes only
+ * {@code save} and query operations — no {@code delete} or {@code update}.
+ */
+@DynamoDbBean
+public class AuditLogRecord {
+
+    /** Name of the GSI for entity-scoped history queries. */
+    public static final String ENTITY_HISTORY_INDEX = "EntityHistoryIndex";
+
+    /** Name of the GSI for actor-scoped history queries. */
+    public static final String ACTOR_HISTORY_INDEX = "ActorHistoryIndex";
+
+    private String logId;
+    private String entityType;  // AuditEntityType.name()
+    private String entityId;
+    private String action;      // AuditAction.name()
+    private String actorId;
+    private Instant timestamp;
+    private String payload;     // JSON delta — what changed and to what value
+
+    public AuditLogRecord() {}
+
+    /** @return the unique log entry ID (partition key) */
+    @DynamoDbPartitionKey
+    public String getLogId() { return logId; }
+    /** @param logId the unique log entry ID */
+    public void setLogId(String logId) { this.logId = logId; }
+
+    /** @return the entity type name (see {@link com.kenzie.appserver.service.model.AuditEntityType}) */
+    public String getEntityType() { return entityType; }
+    /** @param entityType the entity type name */
+    public void setEntityType(String entityType) { this.entityType = entityType; }
+
+    /**
+     * @return the ID of the entity this log entry describes;
+     *         also the partition key of {@value #ENTITY_HISTORY_INDEX}
+     */
+    @DynamoDbSecondaryPartitionKey(indexNames = ENTITY_HISTORY_INDEX)
+    public String getEntityId() { return entityId; }
+    /** @param entityId the entity ID */
+    public void setEntityId(String entityId) { this.entityId = entityId; }
+
+    /** @return the action name (see {@link com.kenzie.appserver.service.model.AuditAction}) */
+    public String getAction() { return action; }
+    /** @param action the action name */
+    public void setAction(String action) { this.action = action; }
+
+    /**
+     * @return the user ID who triggered this event;
+     *         also the partition key of {@value #ACTOR_HISTORY_INDEX}
+     */
+    @DynamoDbSecondaryPartitionKey(indexNames = ACTOR_HISTORY_INDEX)
+    public String getActorId() { return actorId; }
+    /** @param actorId the acting user ID */
+    public void setActorId(String actorId) { this.actorId = actorId; }
+
+    /**
+     * @return the event timestamp (ISO-8601 string in DynamoDB);
+     *         sort key for both {@value #ENTITY_HISTORY_INDEX} and {@value #ACTOR_HISTORY_INDEX}
+     */
+    @DynamoDbSecondarySortKey(indexNames = { ENTITY_HISTORY_INDEX, ACTOR_HISTORY_INDEX })
+    public Instant getTimestamp() { return timestamp; }
+    /** @param timestamp the event timestamp */
+    public void setTimestamp(Instant timestamp) { this.timestamp = timestamp; }
+
+    /**
+     * @return a JSON string describing what changed — shape varies by action
+     *         (e.g. {@code {"oldGoal":5000,"newGoal":10000}} for {@code GOAL_UPDATED})
+     */
+    public String getPayload() { return payload; }
+    /** @param payload the JSON delta payload */
+    public void setPayload(String payload) { this.payload = payload; }
+}

--- a/Application/src/main/java/com/kenzie/appserver/service/AuditLogService.java
+++ b/Application/src/main/java/com/kenzie/appserver/service/AuditLogService.java
@@ -1,0 +1,137 @@
+package com.kenzie.appserver.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kenzie.appserver.repositories.AuditLogDao;
+import com.kenzie.appserver.repositories.model.AuditLogRecord;
+import com.kenzie.appserver.service.model.AuditAction;
+import com.kenzie.appserver.service.model.AuditEntityType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * Append-only audit logging service.
+ *
+ * <p>Provides two write paths:
+ * <ul>
+ *   <li>{@link #logSync} — blocks the calling thread until the record is persisted.
+ *       Use this for financial events ({@code PAYMENT_SUCCEEDED}, {@code PAYMENT_FAILED})
+ *       where the audit entry must be durable before the HTTP response is sent.</li>
+ *   <li>{@link #logAsync} — annotated with {@code @Async}; returns immediately and writes
+ *       on a background thread from the application's executor pool. Use this for
+ *       operational events (campaign created, RSVP confirmed, etc.) where a small write
+ *       delay is acceptable and you don't want to slow the API response.</li>
+ * </ul>
+ *
+ * <p>Async failures are logged at ERROR level but not propagated — a failed audit write
+ * must never crash the business operation that triggered it.
+ *
+ * <p>Sync failures are propagated as {@link AuditLogException} — the caller decides
+ * whether to roll back (financial events should treat an un-logged payment as suspicious).
+ */
+@Service
+public class AuditLogService {
+
+    private static final Logger log = LoggerFactory.getLogger(AuditLogService.class);
+
+    private final AuditLogDao auditLogDao;
+    private final ObjectMapper objectMapper;
+
+    public AuditLogService(AuditLogDao auditLogDao, ObjectMapper objectMapper) {
+        this.auditLogDao = auditLogDao;
+        this.objectMapper = objectMapper;
+    }
+
+    // ── Public write API ───────────────────────────────────────────────────────
+
+    /**
+     * Writes an audit record synchronously. The calling thread blocks until DynamoDB
+     * confirms the write.
+     *
+     * <p>Use for financial events where durability must be confirmed before the
+     * HTTP response is returned to the client.
+     *
+     * @param entityType the category of the affected entity
+     * @param entityId   the ID of the affected entity
+     * @param action     the action that occurred
+     * @param actorId    the user ID who triggered the action
+     * @param payload    an object describing the state delta; serialised to JSON
+     * @throws AuditLogException if the payload cannot be serialised or the DynamoDB write fails
+     */
+    public void logSync(AuditEntityType entityType,
+                        String entityId,
+                        AuditAction action,
+                        String actorId,
+                        Object payload) {
+        persist(entityType, entityId, action, actorId, payload);
+    }
+
+    /**
+     * Writes an audit record asynchronously on a background thread.
+     * Returns immediately; any write failure is logged but not propagated.
+     *
+     * <p>Use for operational events (campaign created, RSVP confirmed, etc.)
+     * where a brief write delay is acceptable.
+     *
+     * @param entityType the category of the affected entity
+     * @param entityId   the ID of the affected entity
+     * @param action     the action that occurred
+     * @param actorId    the user ID who triggered the action
+     * @param payload    an object describing the state delta; serialised to JSON
+     */
+    @Async
+    public void logAsync(AuditEntityType entityType,
+                         String entityId,
+                         AuditAction action,
+                         String actorId,
+                         Object payload) {
+        try {
+            persist(entityType, entityId, action, actorId, payload);
+        } catch (AuditLogException e) {
+            // Async audit failures must never propagate — log and continue.
+            log.error("Async audit log write failed: entityType={} entityId={} action={} actorId={}",
+                    entityType, entityId, action, actorId, e);
+        }
+    }
+
+    // ── Core write ─────────────────────────────────────────────────────────────
+
+    private void persist(AuditEntityType entityType,
+                         String entityId,
+                         AuditAction action,
+                         String actorId,
+                         Object payloadObj) {
+        try {
+            AuditLogRecord record = new AuditLogRecord();
+            record.setLogId(UUID.randomUUID().toString());
+            record.setEntityType(entityType.name());
+            record.setEntityId(entityId);
+            record.setAction(action.name());
+            record.setActorId(actorId);
+            record.setTimestamp(Instant.now());
+            record.setPayload(objectMapper.writeValueAsString(payloadObj));
+
+            auditLogDao.save(record);
+        } catch (JsonProcessingException e) {
+            throw new AuditLogException(
+                    "Failed to serialise audit payload for action " + action, e);
+        }
+    }
+
+    // ── Checked exception ──────────────────────────────────────────────────────
+
+    /**
+     * Thrown by {@link #logSync} when the record cannot be written.
+     * Not used by {@link #logAsync} (failures are swallowed there by design).
+     */
+    public static class AuditLogException extends RuntimeException {
+        public AuditLogException(String message, Throwable cause) {
+            super(message, cause);
+        }
+    }
+}

--- a/Application/src/main/java/com/kenzie/appserver/service/CampaignService.java
+++ b/Application/src/main/java/com/kenzie/appserver/service/CampaignService.java
@@ -7,6 +7,8 @@ import com.kenzie.appserver.controller.model.CreateCampaignRequest;
 import com.kenzie.appserver.repositories.CampaignDao;
 import com.kenzie.appserver.repositories.model.CampaignRecord;
 import com.kenzie.appserver.salesforce.SalesforceService;
+import com.kenzie.appserver.service.model.AuditAction;
+import com.kenzie.appserver.service.model.AuditEntityType;
 import com.kenzie.appserver.service.model.CampaignStatus;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpStatus;
@@ -14,6 +16,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
@@ -25,13 +28,16 @@ public class CampaignService {
     private final CampaignDao campaignDao;
     private final CacheStore<CampaignRecord> cache;
     private final SalesforceService salesforceService;
+    private final AuditLogService auditLogService;
 
     public CampaignService(CampaignDao campaignDao,
                            @Qualifier("campaignCache") CacheStore<CampaignRecord> cache,
-                           SalesforceService salesforceService) {
+                           SalesforceService salesforceService,
+                           AuditLogService auditLogService) {
         this.campaignDao = campaignDao;
         this.cache = cache;
         this.salesforceService = salesforceService;
+        this.auditLogService = auditLogService;
     }
 
     /**
@@ -94,6 +100,10 @@ public class CampaignService {
         campaignDao.save(record);
         salesforceService.syncCampaign(record);
 
+        auditLogService.logAsync(AuditEntityType.CAMPAIGN, record.getId(),
+                AuditAction.CAMPAIGN_CREATED, record.getUser().getId(),
+                Map.of("name", record.getName(), "goalAmount", record.getGoalAmount()));
+
         return recordToResponse(record);
     }
 
@@ -118,6 +128,7 @@ public class CampaignService {
             throw new ResponseStatusException(HttpStatus.CONFLICT, "Cannot update a closed campaign");
         }
 
+        Long oldGoalAmount = record.getGoalAmount();
         record.setName(request.getName());
         record.setDate(request.getDate());
         record.setDeadline(request.getDeadline());
@@ -126,9 +137,20 @@ public class CampaignService {
         record.setSupporters(request.getSupporters());
         record.setAddress(request.getAddress());
         record.setDescription(request.getDescription());
+        boolean goalChanged = !Objects.equals(oldGoalAmount, request.getGoalAmount());
         record.setGoalAmount(request.getGoalAmount());
         campaignDao.save(record);
         cache.evict(record.getId());
+
+        if (goalChanged) {
+            auditLogService.logAsync(AuditEntityType.CAMPAIGN, record.getId(),
+                    AuditAction.GOAL_UPDATED, requestingUserId,
+                    Map.of("oldGoal", oldGoalAmount, "newGoal", request.getGoalAmount()));
+        } else {
+            auditLogService.logAsync(AuditEntityType.CAMPAIGN, record.getId(),
+                    AuditAction.CAMPAIGN_UPDATED, requestingUserId,
+                    Map.of("name", record.getName()));
+        }
 
         return recordToResponse(record);
     }
@@ -171,6 +193,15 @@ public class CampaignService {
         cache.evict(campaignId);
         salesforceService.syncDonation(record, amountInCents);
 
+        // Synchronous: the donation must be in the audit log before the response is sent.
+        // actorId is unknown here (Stripe webhook path has no authenticated user);
+        // use the campaign owner as the contextual actor for the ledger record.
+        String actorId = record.getUser() != null ? record.getUser().getId() : "system";
+        auditLogService.logSync(AuditEntityType.DONATION, campaignId,
+                AuditAction.PAYMENT_SUCCEEDED, actorId,
+                Map.of("amountInCents", amountInCents, "newTotalCents", newTotal,
+                        "status", record.getStatus()));
+
         return recordToResponse(record);
     }
 
@@ -199,17 +230,22 @@ public class CampaignService {
         campaignDao.save(record);
         cache.evict(campaignId);
 
+        auditLogService.logAsync(AuditEntityType.CAMPAIGN, campaignId,
+                AuditAction.CAMPAIGN_CLOSED, requestingUserId,
+                Map.of("finalStatus", CampaignStatus.CLOSED.name()));
+
         return recordToResponse(record);
     }
 
     /**
      * Permanently deletes a campaign and evicts it from the cache.
      *
-     * @param campaignId the campaign to delete
+     * @param campaignId       the campaign to delete
+     * @param requestingUserId the user ID from the authenticated JWT
      * @throws org.springframework.web.server.ResponseStatusException 400 if ID is blank,
      *         404 if not found
      */
-    public void deleteCampaign(String campaignId) {
+    public void deleteCampaign(String campaignId, String requestingUserId) {
         if (campaignId == null || campaignId.isBlank()) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Campaign ID cannot be empty");
         }
@@ -218,6 +254,10 @@ public class CampaignService {
         }
         campaignDao.deleteById(campaignId);
         cache.evict(campaignId);
+
+        auditLogService.logAsync(AuditEntityType.CAMPAIGN, campaignId,
+                AuditAction.CAMPAIGN_DELETED, requestingUserId,
+                Map.of("campaignId", campaignId));
     }
 
     /**

--- a/Application/src/main/java/com/kenzie/appserver/service/FundraisingEventService.java
+++ b/Application/src/main/java/com/kenzie/appserver/service/FundraisingEventService.java
@@ -7,6 +7,8 @@ import com.kenzie.appserver.controller.model.EventUpdateRequest;
 import com.kenzie.appserver.controller.model.RsvpRequest;
 import com.kenzie.appserver.repositories.FundraisingEventDao;
 import com.kenzie.appserver.repositories.model.FundraisingEventRecord;
+import com.kenzie.appserver.service.model.AuditAction;
+import com.kenzie.appserver.service.model.AuditEntityType;
 import com.kenzie.appserver.service.model.EventStatus;
 import com.kenzie.appserver.service.model.RsvpStatus;
 import com.kenzie.appserver.service.model.Volunteer;
@@ -18,6 +20,7 @@ import org.springframework.web.server.ResponseStatusException;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
@@ -36,11 +39,14 @@ public class FundraisingEventService {
 
     private final FundraisingEventDao eventDao;
     private final CacheStore<FundraisingEventRecord> cache;
+    private final AuditLogService auditLogService;
 
     public FundraisingEventService(FundraisingEventDao eventDao,
-                                   @Qualifier("eventCache") CacheStore<FundraisingEventRecord> cache) {
+                                   @Qualifier("eventCache") CacheStore<FundraisingEventRecord> cache,
+                                   AuditLogService auditLogService) {
         this.eventDao = eventDao;
         this.cache = cache;
+        this.auditLogService = auditLogService;
     }
 
     // ── Reads ──────────────────────────────────────────────────────────────────
@@ -136,6 +142,10 @@ public class FundraisingEventService {
         record.setStatus(EventStatus.PLANNING.name());
         eventDao.save(record);
 
+        auditLogService.logAsync(AuditEntityType.FUNDRAISING_EVENT, record.getId(),
+                AuditAction.EVENT_CREATED, request.getOrganizer().getId(),
+                Map.of("name", record.getName(), "campaignId", record.getCampaignId()));
+
         return recordToResponse(record);
     }
 
@@ -170,6 +180,10 @@ public class FundraisingEventService {
         eventDao.save(record);
         cache.evict(CACHE_PREFIX + record.getId());
 
+        auditLogService.logAsync(AuditEntityType.FUNDRAISING_EVENT, record.getId(),
+                AuditAction.EVENT_UPDATED, requestingUserId,
+                Map.of("name", record.getName()));
+
         return recordToResponse(record);
     }
 
@@ -196,6 +210,10 @@ public class FundraisingEventService {
         eventDao.save(record);
         cache.evict(CACHE_PREFIX + eventId);
 
+        auditLogService.logAsync(AuditEntityType.FUNDRAISING_EVENT, eventId,
+                AuditAction.EVENT_PUBLISHED, requestingUserId,
+                Map.of("status", EventStatus.SCHEDULED.name()));
+
         return recordToResponse(record);
     }
 
@@ -217,6 +235,10 @@ public class FundraisingEventService {
         record.setStatus(EventStatus.CANCELLED.name());
         eventDao.save(record);
         cache.evict(CACHE_PREFIX + eventId);
+
+        auditLogService.logAsync(AuditEntityType.FUNDRAISING_EVENT, eventId,
+                AuditAction.EVENT_CANCELLED, requestingUserId,
+                Map.of("status", EventStatus.CANCELLED.name()));
 
         return recordToResponse(record);
     }
@@ -244,6 +266,10 @@ public class FundraisingEventService {
 
         eventDao.deleteById(eventId);
         cache.evict(CACHE_PREFIX + eventId);
+
+        auditLogService.logAsync(AuditEntityType.FUNDRAISING_EVENT, eventId,
+                AuditAction.EVENT_DELETED, requestingUserId,
+                Map.of("eventId", eventId));
     }
 
     // ── RSVP ──────────────────────────────────────────────────────────────────
@@ -305,6 +331,13 @@ public class FundraisingEventService {
         eventDao.save(record);
         cache.evict(CACHE_PREFIX + eventId);
 
+        AuditAction rsvpAction = RsvpStatus.CONFIRMED.name().equals(status)
+                ? AuditAction.RSVP_CONFIRMED
+                : AuditAction.RSVP_WAITLISTED;
+        auditLogService.logAsync(AuditEntityType.RSVP, eventId,
+                rsvpAction, request.getVolunteerId(),
+                Map.of("volunteerId", request.getVolunteerId(), "rsvpStatus", status));
+
         return recordToResponse(record);
     }
 
@@ -341,16 +374,26 @@ public class FundraisingEventService {
         target.setRsvpStatus(RsvpStatus.CANCELLED.name());
 
         // Promote first waitlisted volunteer when a confirmed spot opens
+        Optional<Volunteer> promoted = Optional.empty();
         if (wasConfirmed) {
-            volunteers.stream()
+            promoted = volunteers.stream()
                     .filter(v -> RsvpStatus.WAITLISTED.name().equals(v.getRsvpStatus()))
-                    .findFirst()
-                    .ifPresent(v -> v.setRsvpStatus(RsvpStatus.CONFIRMED.name()));
+                    .findFirst();
+            promoted.ifPresent(v -> v.setRsvpStatus(RsvpStatus.CONFIRMED.name()));
         }
 
         record.setVolunteers(volunteers);
         eventDao.save(record);
         cache.evict(CACHE_PREFIX + eventId);
+
+        auditLogService.logAsync(AuditEntityType.RSVP, eventId,
+                AuditAction.RSVP_CANCELLED, volunteerId,
+                Map.of("volunteerId", volunteerId));
+
+        promoted.ifPresent(v ->
+                auditLogService.logAsync(AuditEntityType.RSVP, eventId,
+                        AuditAction.RSVP_PROMOTED_FROM_WAITLIST, v.getId(),
+                        Map.of("volunteerId", v.getId())));
 
         return recordToResponse(record);
     }

--- a/Application/src/main/java/com/kenzie/appserver/service/model/AuditAction.java
+++ b/Application/src/main/java/com/kenzie/appserver/service/model/AuditAction.java
@@ -1,0 +1,62 @@
+package com.kenzie.appserver.service.model;
+
+/**
+ * Semantic action names written to the audit log.
+ *
+ * <p>Grouped by entity type for readability. The {@code entityType} field on the
+ * {@link com.kenzie.appserver.repositories.model.AuditLogRecord} tells the consumer
+ * which group applies, but actions are kept in a single enum so callers get compile-time
+ * safety without juggling multiple types.
+ *
+ * <p>Add new values here before writing to the log — never use raw strings for actions.
+ */
+public enum AuditAction {
+
+    // ── Campaign ───────────────────────────────────────────────────────────────
+    /** A new campaign was created. */
+    CAMPAIGN_CREATED,
+    /** A campaign's mutable fields were updated. */
+    CAMPAIGN_UPDATED,
+    /** A campaign's fundraising goal was changed. */
+    GOAL_UPDATED,
+    /** A campaign was moved to CLOSED status. */
+    CAMPAIGN_CLOSED,
+    /** A campaign was permanently deleted. */
+    CAMPAIGN_DELETED,
+
+    // ── Donation ───────────────────────────────────────────────────────────────
+    /** A Stripe PaymentIntent was created; payment not yet captured. */
+    PAYMENT_INITIATED,
+    /** Stripe confirmed the payment succeeded; donation recorded. */
+    PAYMENT_SUCCEEDED,
+    /** Stripe reported a payment failure. */
+    PAYMENT_FAILED,
+
+    // ── Fundraising Event ──────────────────────────────────────────────────────
+    /** A new fundraising event was created in PLANNING status. */
+    EVENT_CREATED,
+    /** An event's mutable fields were updated. */
+    EVENT_UPDATED,
+    /** An event was moved from PLANNING to SCHEDULED. */
+    EVENT_PUBLISHED,
+    /** An event was cancelled. */
+    EVENT_CANCELLED,
+    /** A PLANNING-status event was permanently deleted. */
+    EVENT_DELETED,
+
+    // ── RSVP ──────────────────────────────────────────────────────────────────
+    /** A volunteer was confirmed for an event. */
+    RSVP_CONFIRMED,
+    /** A volunteer was added to the waitlist. */
+    RSVP_WAITLISTED,
+    /** A volunteer cancelled their RSVP. */
+    RSVP_CANCELLED,
+    /** A waitlisted volunteer was promoted to CONFIRMED after a cancellation. */
+    RSVP_PROMOTED_FROM_WAITLIST,
+
+    // ── User ───────────────────────────────────────────────────────────────────
+    /** A new user account was registered. */
+    USER_REGISTERED,
+    /** A user's profile was updated. */
+    USER_UPDATED
+}

--- a/Application/src/main/java/com/kenzie/appserver/service/model/AuditEntityType.java
+++ b/Application/src/main/java/com/kenzie/appserver/service/model/AuditEntityType.java
@@ -1,0 +1,27 @@
+package com.kenzie.appserver.service.model;
+
+/**
+ * Identifies which domain entity an {@link com.kenzie.appserver.repositories.model.AuditLogRecord}
+ * describes.
+ *
+ * <p>Used as the {@code entityType} field in the audit log so that consumers (dashboard queries,
+ * Salesforce sync, EventBridge routing rules) can filter by entity category without inspecting
+ * the payload.
+ */
+public enum AuditEntityType {
+
+    /** A fundraising campaign. */
+    CAMPAIGN,
+
+    /** A financial donation tied to a campaign. */
+    DONATION,
+
+    /** A volunteer fundraising event. */
+    FUNDRAISING_EVENT,
+
+    /** A volunteer RSVP on a fundraising event. */
+    RSVP,
+
+    /** A platform user account. */
+    USER
+}

--- a/Application/src/test/java/com/kenzie/appserver/service/CampaignServiceTest.java
+++ b/Application/src/test/java/com/kenzie/appserver/service/CampaignServiceTest.java
@@ -33,6 +33,8 @@ import static org.mockito.Mockito.*;
 @ExtendWith(MockitoExtension.class)
 class CampaignServiceTest {
 
+    private static final String USER_ID = "user-1";
+
     @Mock
     private CampaignDao campaignDao;
 
@@ -41,6 +43,9 @@ class CampaignServiceTest {
 
     @Mock
     private SalesforceService salesforceService;
+
+    @Mock
+    private AuditLogService auditLogService;
 
     @InjectMocks
     private CampaignService campaignService;
@@ -463,7 +468,7 @@ class CampaignServiceTest {
     void deleteCampaign_nullId_throwsBadRequest() {
         ResponseStatusException ex = assertThrows(
                 ResponseStatusException.class,
-                () -> campaignService.deleteCampaign(null)
+                () -> campaignService.deleteCampaign(null, USER_ID)
         );
         assertEquals(HttpStatus.BAD_REQUEST, ex.getStatusCode());
     }
@@ -472,7 +477,7 @@ class CampaignServiceTest {
     void deleteCampaign_blankId_throwsBadRequest() {
         ResponseStatusException ex = assertThrows(
                 ResponseStatusException.class,
-                () -> campaignService.deleteCampaign("   ")
+                () -> campaignService.deleteCampaign("   ", USER_ID)
         );
         assertEquals(HttpStatus.BAD_REQUEST, ex.getStatusCode());
     }
@@ -481,7 +486,7 @@ class CampaignServiceTest {
     void deleteCampaign_emptyId_throwsBadRequest() {
         ResponseStatusException ex = assertThrows(
                 ResponseStatusException.class,
-                () -> campaignService.deleteCampaign("")
+                () -> campaignService.deleteCampaign("", USER_ID)
         );
         assertEquals(HttpStatus.BAD_REQUEST, ex.getStatusCode());
     }
@@ -493,7 +498,7 @@ class CampaignServiceTest {
 
         ResponseStatusException ex = assertThrows(
                 ResponseStatusException.class,
-                () -> campaignService.deleteCampaign(id)
+                () -> campaignService.deleteCampaign(id, USER_ID)
         );
         assertEquals(HttpStatus.NOT_FOUND, ex.getStatusCode());
     }
@@ -503,7 +508,7 @@ class CampaignServiceTest {
         String id = UUID.randomUUID().toString();
         when(campaignDao.existsById(id)).thenReturn(true);
 
-        campaignService.deleteCampaign(id);
+        campaignService.deleteCampaign(id, USER_ID);
 
         verify(campaignDao).deleteById(id);
         verify(cache).evict(id);

--- a/AuditLogTable.yml
+++ b/AuditLogTable.yml
@@ -1,0 +1,50 @@
+Resources:
+  AuditLogTable:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      TableName: "AuditLog"
+      BillingMode: PAY_PER_REQUEST
+      PointInTimeRecoverySpecification:
+        # Enable PITR on the audit log — the compliance record must be recoverable.
+        PointInTimeRecoveryEnabled: true
+      AttributeDefinitions:
+        - AttributeName: "logId"
+          AttributeType: "S"
+        - AttributeName: "entityId"
+          AttributeType: "S"
+        - AttributeName: "actorId"
+          AttributeType: "S"
+        - AttributeName: "timestamp"
+          AttributeType: "S"   # ISO-8601 string; sorts correctly lexicographically
+      KeySchema:
+        - AttributeName: "logId"
+          KeyType: "HASH"      # UUID — prevents hot partitions on busy entities
+      GlobalSecondaryIndexes:
+        - IndexName: "EntityHistoryIndex"
+          KeySchema:
+            - AttributeName: "entityId"
+              KeyType: "HASH"
+            - AttributeName: "timestamp"
+              KeyType: "RANGE"
+          Projection:
+            ProjectionType: ALL
+        - IndexName: "ActorHistoryIndex"
+          KeySchema:
+            - AttributeName: "actorId"
+              KeyType: "HASH"
+            - AttributeName: "timestamp"
+              KeyType: "RANGE"
+          Projection:
+            ProjectionType: ALL
+
+# Notes:
+#  - PITR is ENABLED (unlike other tables) — the audit log is the compliance record.
+#  - Records must never be deleted; no TTL is set on this table.
+#  - Add a third GSI on (entityType, timestamp) when you build the admin analytics
+#    dashboard and need "all DONATION events platform-wide in the last 30 days".
+#
+# Deploy:
+#   aws cloudformation create-stack \
+#     --stack-name audit-log \
+#     --template-body file://AuditLogTable.yml \
+#     --capabilities CAPABILITY_IAM


### PR DESCRIPTION
## Summary

- **`AuditEntityType`** — enum identifying which domain entity a log entry describes (CAMPAIGN, DONATION, FUNDRAISING_EVENT, RSVP, USER)
- **`AuditAction`** — 25 semantic action names with compile-time safety; no raw strings anywhere in the codebase
- **`AuditLogRecord`** — `@DynamoDbBean` with `logId` UUID partition key (prevents hot partitions) and two GSIs:
  - `EntityHistoryIndex` (entityId PK + timestamp SK) — "timeline for Campaign X"
  - `ActorHistoryIndex` (actorId PK + timestamp SK) — "everything user Y has ever done"; directly powers the Step 2 Dashboard and Salesforce 360 profile
- **`AuditLogDao`** — append-only by design; exposes `save`, `findByEntityId`, `findByActorId` only — no `delete` or `update`
- **`AuditLogService`** — two write paths:
  - `logSync` — blocks the calling thread; used for `PAYMENT_SUCCEEDED` where the record must be durable before the HTTP response goes out
  - `logAsync` (`@Async`) — returns immediately; failures are logged at ERROR level but never propagated, so an audit write failure cannot crash the business operation
- **`AuditLogTable.yml`** — CloudFormation with **PITR enabled** (unlike other tables) and both GSIs declared

## Wired into domain services

| Service | Events | Sync? |
|---|---|---|
| `CampaignService` | `CAMPAIGN_CREATED`, `GOAL_UPDATED`, `CAMPAIGN_UPDATED`, `CAMPAIGN_CLOSED`, `CAMPAIGN_DELETED` | Async |
| `CampaignService` | `PAYMENT_SUCCEEDED` | **Sync** |
| `FundraisingEventService` | `EVENT_CREATED`, `EVENT_UPDATED`, `EVENT_PUBLISHED`, `EVENT_CANCELLED`, `EVENT_DELETED` | Async |
| `FundraisingEventService` | `RSVP_CONFIRMED`, `RSVP_WAITLISTED`, `RSVP_CANCELLED`, `RSVP_PROMOTED_FROM_WAITLIST` | Async |

## What this unlocks next

- **Step 2 (Dashboard):** `AuditLogDao.findByActorId(userId)` returns the user's complete cross-platform history with a single GSI query — no table scan needed
- **Salesforce Data Cloud:** pipe `ActorHistoryIndex` records to build unified 360-degree supporter profiles
- **DynamoDB Streams (future):** layer on as a safety net to catch any changes that bypass the service layer

## Test plan

- [ ] `./gradlew :Application:compileJava :Application:test` passes
- [ ] CI (`build-and-test` + `frontend-lint`) both green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Comprehensive audit logging now records campaign lifecycle events including creation, updates, goal changes, closures, and deletions.
  * Fundraising event activities and RSVP confirmations/cancellations are tracked.
  * Donation and payment transactions are logged.
  * Campaign deletion now requires user authentication.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/staceySpears/generositywell-fundraising-platform/pull/17)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->