### PR TITLE
fix: resolve 18 unresolved CodeRabbit findings from PRs #2–#16

### DIFF
--- a/Application/src/main/java/com/kenzie/appserver/controller/CampaignController.java
+++ b/Application/src/main/java/com/kenzie/appserver/controller/CampaignController.java
@@ -9,9 +9,11 @@ import com.kenzie.appserver.controller.model.PaymentIntentResponse;
 import com.kenzie.appserver.service.CampaignService;
 import com.kenzie.appserver.service.StripeService;
 import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.net.URI;
 import java.util.List;
@@ -67,8 +69,14 @@ public class CampaignController {
      */
     @PutMapping("/{campaignId}")
     public ResponseEntity<CampaignResponse> updateCampaign(
+            @PathVariable("campaignId") String campaignId,
             @Valid @RequestBody CampaignUpdateRequest request,
             Authentication authentication) {
+        if (request.getId() != null && !campaignId.equals(request.getId())) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    "Path campaignId must match body id");
+        }
+        request.setId(campaignId);
         CampaignResponse response = campaignService.updateCampaign(request, authentication.getName());
         return ResponseEntity.ok(response);
     }

--- a/Application/src/main/java/com/kenzie/appserver/controller/FundraisingEventController.java
+++ b/Application/src/main/java/com/kenzie/appserver/controller/FundraisingEventController.java
@@ -94,8 +94,10 @@ public class FundraisingEventController {
      */
     @PutMapping("/{id}")
     public ResponseEntity<EventResponse> updateEvent(
+            @PathVariable("id") String id,
             @Valid @RequestBody EventUpdateRequest request,
             Authentication authentication) {
+        request.setId(id);
         EventResponse response = eventService.updateEvent(request, authentication.getName());
         return ResponseEntity.ok(response);
     }
@@ -162,6 +164,9 @@ public class FundraisingEventController {
             @PathVariable("id") String id,
             @Valid @RequestBody RsvpRequest request,
             Authentication authentication) {
+        // Override the volunteerId from JWT subject — the server, not the client,
+        // determines who is RSVPing. Name and email are still accepted from the body.
+        request.setVolunteerId(authentication.getName());
         return ResponseEntity.ok(eventService.rsvp(id, request));
     }
 

--- a/Application/src/main/java/com/kenzie/appserver/controller/GlobalExceptionHandler.java
+++ b/Application/src/main/java/com/kenzie/appserver/controller/GlobalExceptionHandler.java
@@ -61,7 +61,7 @@ public class GlobalExceptionHandler {
      */
     @ExceptionHandler(HttpMessageNotReadableException.class)
     public ResponseEntity<Map<String, Object>> handleMessageNotReadable(HttpMessageNotReadableException ex) {
-        log.warn("Unreadable request body: {}", ex.getMessage());
+        log.warn("Unreadable request body");
         return buildErrorResponse(HttpStatus.BAD_REQUEST, "Request body is missing or malformed");
     }
 

--- a/Application/src/main/java/com/kenzie/appserver/controller/UserController.java
+++ b/Application/src/main/java/com/kenzie/appserver/controller/UserController.java
@@ -57,10 +57,11 @@ public class UserController {
      * @return 200 with the updated user, or 404 if not found
      */
     @PutMapping("/{id}")
-    public ResponseEntity<UserResponse> updateUser(@Valid @RequestBody UserUpdateRequest userUpdateRequest) {
-
+    public ResponseEntity<UserResponse> updateUser(
+            @PathVariable("id") String id,
+            @Valid @RequestBody UserUpdateRequest userUpdateRequest) {
+        userUpdateRequest.setId(id);
         UserResponse userResponse = userService.updateUser(userUpdateRequest);
-
         return ResponseEntity.ok(userResponse);
     }
 

--- a/Application/src/main/java/com/kenzie/appserver/repositories/UserDao.java
+++ b/Application/src/main/java/com/kenzie/appserver/repositories/UserDao.java
@@ -15,7 +15,7 @@ import java.util.Optional;
 @Repository
 public class UserDao {
 
-    private static final String TABLE_NAME = "Users";
+    private static final String TABLE_NAME = "users";
     private static final String EMAIL_INDEX = "email-index";
 
     private final DynamoDbTable<UserRecord> userTable;
@@ -71,7 +71,7 @@ public class UserDao {
     /**
      * Finds a user by email address using the {@code email-index} GSI.
      * O(1) DynamoDB query — replaces the previous O(n) full table scan.
-     * Requires the {@code email-index} GSI to exist on the {@code Users} table
+     * Requires the {@code email-index} GSI to exist on the {@code users} table
      * (see {@code UsersTable.yml}).
      *
      * @param email the email address to search for

--- a/Application/src/main/java/com/kenzie/appserver/repositories/model/VolunteerTypeConverter.java
+++ b/Application/src/main/java/com/kenzie/appserver/repositories/model/VolunteerTypeConverter.java
@@ -6,6 +6,9 @@ import software.amazon.awssdk.enhanced.dynamodb.AttributeValueType;
 import software.amazon.awssdk.enhanced.dynamodb.EnhancedType;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
+import java.net.URLDecoder;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -16,6 +19,8 @@ import java.util.stream.Collectors;
  * {@code "id|name|email|rsvpStatus"} and stored in a DynamoDB List ({@code L}).
  * Pipe ({@code |}) was chosen over {@code x} (used by {@link SupporterTypeConverter}) to
  * avoid ambiguity with names that contain the letter 'x'.
+ * Each field is URL-encoded before joining so that pipes inside field values
+ * (e.g. {@code "Jane | Doe"}) are percent-encoded and never mistaken for delimiters.
  */
 public class VolunteerTypeConverter implements AttributeConverter<List<Volunteer>> {
 
@@ -36,10 +41,10 @@ public class VolunteerTypeConverter implements AttributeConverter<List<Volunteer
         List<AttributeValue> items = input.stream()
                 .map(v -> AttributeValue.builder()
                         .s(String.join(DELIMITER,
-                                v.getId(),
-                                v.getName(),
-                                v.getEmail(),
-                                v.getRsvpStatus()))
+                                encode(v.getId()),
+                                encode(v.getName()),
+                                encode(v.getEmail()),
+                                encode(v.getRsvpStatus())))
                         .build())
                 .collect(Collectors.toList());
         return AttributeValue.builder().l(items).build();
@@ -55,11 +60,16 @@ public class VolunteerTypeConverter implements AttributeConverter<List<Volunteer
     public List<Volunteer> transformTo(AttributeValue input) {
         return input.l().stream().map(av -> {
             String[] parts = av.s().split(DELIMITER_REGEX, 4);
+            if (parts.length != 4) {
+                throw new IllegalStateException(
+                        "Corrupt volunteer record — expected 4 pipe-delimited fields, got "
+                                + parts.length + ": " + av.s());
+            }
             Volunteer volunteer = new Volunteer();
-            volunteer.setId(parts[0]);
-            volunteer.setName(parts[1]);
-            volunteer.setEmail(parts[2]);
-            volunteer.setRsvpStatus(parts[3]);
+            volunteer.setId(decode(parts[0]));
+            volunteer.setName(decode(parts[1]));
+            volunteer.setEmail(decode(parts[2]));
+            volunteer.setRsvpStatus(decode(parts[3]));
             return volunteer;
         }).collect(Collectors.toList());
     }
@@ -74,5 +84,13 @@ public class VolunteerTypeConverter implements AttributeConverter<List<Volunteer
     @Override
     public AttributeValueType attributeValueType() {
         return AttributeValueType.L;
+    }
+
+    private static String encode(String value) {
+        return value == null ? "" : URLEncoder.encode(value, StandardCharsets.UTF_8);
+    }
+
+    private static String decode(String value) {
+        return value == null ? "" : URLDecoder.decode(value, StandardCharsets.UTF_8);
     }
 }

--- a/Application/src/main/java/com/kenzie/appserver/service/FundraisingEventService.java
+++ b/Application/src/main/java/com/kenzie/appserver/service/FundraisingEventService.java
@@ -130,6 +130,10 @@ public class FundraisingEventService {
         if (request.getOrganizer() == null) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Event must have an organizer");
         }
+        if (request.getCapacity() != null && request.getCapacity() < 1) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    "Capacity must be a positive number (or null for unlimited)");
+        }
         if (request.getEventDate() != null && request.getRegistrationDeadline() != null
                 && request.getRegistrationDeadline().isAfter(request.getEventDate())) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
@@ -175,6 +179,22 @@ public class FundraisingEventService {
 
         if (request.getName() == null || request.getName().isBlank()) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Event name is required");
+        }
+        if (request.getCapacity() != null && request.getCapacity() < 1) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    "Capacity must be a positive number (or null for unlimited)");
+        }
+        if (request.getCapacity() != null) {
+            List<Volunteer> current = record.getVolunteers() != null
+                    ? record.getVolunteers() : List.of();
+            long confirmedCount = current.stream()
+                    .filter(v -> RsvpStatus.CONFIRMED.name().equals(v.getRsvpStatus()))
+                    .count();
+            if (request.getCapacity() < confirmedCount) {
+                throw new ResponseStatusException(HttpStatus.CONFLICT,
+                        "New capacity (" + request.getCapacity()
+                                + ") is less than the current confirmed count (" + confirmedCount + ")");
+            }
         }
         if (request.getEventDate() != null && request.getRegistrationDeadline() != null
                 && request.getRegistrationDeadline().isAfter(request.getEventDate())) {

--- a/Frontend/src/api/client.js
+++ b/Frontend/src/api/client.js
@@ -5,9 +5,13 @@ import axios from 'axios';
  *
  * In development, Vite proxies /api/* → http://localhost:5001/*.
  * In production set VITE_API_BASE_URL to your API domain.
+ *
+ * A 10-second request timeout is applied globally. Override per-request by
+ * passing { timeout: <ms> } in the individual call's config object.
  */
 const client = axios.create({
   baseURL: import.meta.env.VITE_API_BASE_URL ?? '/api',
+  timeout: 10_000,
 });
 
 // Attach the JWT on every request if one is stored.

--- a/Frontend/src/context/AuthContext.jsx
+++ b/Frontend/src/context/AuthContext.jsx
@@ -8,6 +8,17 @@ import { login as apiLogin, register as apiRegister } from '../api/userApi.js';
 export const AuthContext = createContext(null);
 
 /**
+ * Returns the stored value only when it is a non-empty, non-sentinel string.
+ * Guards against localStorage containing the literal strings "undefined" or "null"
+ * that result from stringifying JS primitives, which would otherwise be truthy.
+ *
+ * @param {string|null} value the raw localStorage value
+ * @returns {string|null} the value or null if it is missing/sentinel
+ */
+const normalizeStored = (value) =>
+  value && value !== 'undefined' && value !== 'null' ? value : null;
+
+/**
  * Provides { token, userId, isAuthenticated, login, register, logout } to the tree.
  *
  * Security note: the JWT is currently stored in localStorage for simplicity.
@@ -21,15 +32,24 @@ export const AuthContext = createContext(null);
  *  - 'gw:auth:expired': fired by the Axios 401 interceptor (same-tab expiry)
  */
 export function AuthProvider({ children }) {
-  const [token, setToken] = useState(() => localStorage.getItem('gw_token'));
-  const [userId, setUserId] = useState(() => localStorage.getItem('gw_userId'));
+  const [token, setToken] = useState(() => normalizeStored(localStorage.getItem('gw_token')));
+  const [userId, setUserId] = useState(() => normalizeStored(localStorage.getItem('gw_userId')));
   const navigate = useNavigate();
 
   // ── Cross-tab sync + interceptor-triggered logout ──────────────────────────
   useEffect(() => {
-    const syncFromStorage = () => {
-      setToken(localStorage.getItem('gw_token'));
-      setUserId(localStorage.getItem('gw_userId'));
+    const syncFromStorage = (event) => {
+      // Ignore storage events for keys unrelated to auth.
+      if (event.key !== null && event.key !== 'gw_token' && event.key !== 'gw_userId') {
+        return;
+      }
+      const newToken = normalizeStored(localStorage.getItem('gw_token'));
+      setToken(newToken);
+      setUserId(normalizeStored(localStorage.getItem('gw_userId')));
+      // If the token was removed in another tab, redirect to login here too.
+      if (!newToken) {
+        navigate('/login', { replace: true });
+      }
     };
 
     const handleExpired = () => {

--- a/Frontend/src/index.css
+++ b/Frontend/src/index.css
@@ -34,7 +34,7 @@ body,
 }
 
 body {
-  font-family: 'Inter', system-ui, sans-serif;
+  font-family: Inter, system-ui, sans-serif;
   background-color: var(--color-bg);
   color: var(--color-text);
   -webkit-font-smoothing: antialiased;

--- a/Frontend/src/pages/CalendarPage/CalendarPage.jsx
+++ b/Frontend/src/pages/CalendarPage/CalendarPage.jsx
@@ -74,7 +74,11 @@ export default function CalendarPage() {
                 <div className={styles.itemBody}>
                   <div className={styles.itemHeader}>
                     <span className={styles.eventName}>{event.name}</span>
-                    <span className={`${styles.dot} ${STATUS_DOT[event.status] ?? ''}`} />
+                    <span
+                      className={`${styles.dot} ${STATUS_DOT[event.status] ?? ''}`}
+                      role="img"
+                      aria-label={`Status: ${event.status ?? 'Unknown'}`}
+                    />
                   </div>
                   {event.location && <span className={styles.location}>{event.location}</span>}
                   <div className={styles.itemFooter}>

--- a/Frontend/src/pages/DashboardPage/DashboardPage.module.css
+++ b/Frontend/src/pages/DashboardPage/DashboardPage.module.css
@@ -1,4 +1,5 @@
 .container {
+  width: 100%;
 }
 .state {
   color: var(--color-text-muted);

--- a/Frontend/src/pages/ForgotPasswordPage/ForgotPasswordPage.jsx
+++ b/Frontend/src/pages/ForgotPasswordPage/ForgotPasswordPage.jsx
@@ -3,7 +3,7 @@ import styles from './ForgotPasswordPage.module.css';
 
 /**
  * Placeholder — password reset requires a backend email flow (Phase 5).
- * The form is rendered but submission is a no-op until the endpoint exists.
+ * UI-only for now; actual reset submission will be added once the endpoint exists.
  */
 export default function ForgotPasswordPage() {
   return (

--- a/Frontend/src/pages/LoginPage/LoginPage.jsx
+++ b/Frontend/src/pages/LoginPage/LoginPage.jsx
@@ -29,7 +29,7 @@ export default function LoginPage() {
     try {
       await login(values);
       navigate(from, { replace: true });
-    } catch (err) {
+    } catch {
       setServerError('Invalid email or password. Please try again.');
     }
   };

--- a/Frontend/src/pages/LoginPage/LoginPage.jsx
+++ b/Frontend/src/pages/LoginPage/LoginPage.jsx
@@ -11,7 +11,10 @@ export default function LoginPage() {
   const { login } = useAuth();
   const navigate = useNavigate();
   const location = useLocation();
-  const from = location.state?.from?.pathname ?? '/dashboard';
+  const fromLocation = location.state?.from;
+  const from = fromLocation?.pathname
+    ? `${fromLocation.pathname}${fromLocation.search ?? ''}${fromLocation.hash ?? ''}`
+    : '/dashboard';
 
   const [serverError, setServerError] = useState('');
 
@@ -27,7 +30,7 @@ export default function LoginPage() {
       await login(values);
       navigate(from, { replace: true });
     } catch (err) {
-      setServerError(err.response?.data?.message ?? 'Invalid email or password. Please try again.');
+      setServerError('Invalid email or password. Please try again.');
     }
   };
 


### PR DESCRIPTION
## Summary

Addresses every unresolved CodeRabbit thread from the project's merged PRs (#2–#16). All changes were verified against current code before fixing; already-resolved or by-design findings are skipped with reasons.

### Backend (9 fixes)
- **`CampaignController`** — bind `@PathVariable("campaignId")` on `PUT /{campaignId}`; reject path/body ID mismatch with 400; set `request.id` from path (source of truth)
- **`UserController`** — bind `@PathVariable("id")` on `PUT /{id}`; override body ID with path ID
- **`FundraisingEventController`** — bind `@PathVariable("id")` on `PUT /{id}`; override RSVP `volunteerId` from JWT subject so clients cannot RSVP on behalf of other users (🔴 Critical security fix)
- **`UserDao`** — `TABLE_NAME "Users"` → `"users"` to match `UsersTable.yml` (DynamoDB names are case-sensitive)
- **`GlobalExceptionHandler`** — remove `ex.getMessage()` from unreadable-body log warn (prevents request payload fragments/PII leaking into logs)
- **`VolunteerTypeConverter`** — URL-encode each field on write / decode on read so pipe characters in names/emails can't corrupt the delimiter; add `parts.length == 4` bounds check to fail fast on corrupt records (2 × 🔴 Critical fixes)
- **`FundraisingEventService`** — reject capacity ≤ 0 on create; on update also reject if new capacity < current confirmed count

### Frontend (9 fixes)
- **`client.js`** — add 10-second default request timeout to Axios instance
- **`AuthContext`** — `normalizeStored()` rejects sentinel strings (`"undefined"`/`"null"`) from localStorage; `syncFromStorage` filters unrelated storage events and redirects to `/login` when token is removed in another tab
- **`index.css`** — unquote `Inter` font-family to satisfy stylelint
- **`DashboardPage.module.css`** — add `width: 100%` to `.container` (was empty block — `block-no-empty` lint failure)
- **`ForgotPasswordPage.jsx`** — correct stale docblock (no form exists in the component)
- **`LoginPage.jsx`** — preserve full return URL (`pathname+search+hash`) after login; replace raw backend error with a generic user-facing message
- **`CalendarPage.jsx`** — add `role="img"` + `aria-label` to status dot (color-only indicator, no accessibility signal)

### Skipped (with reason)
| Finding | Reason |
|---------|--------|
| `CampaignRecord` field rename (`startDate`/`goalAmountCents`) | Entire app built on current field names — breaking schema change with no CF template to check against |
| Stripe webhook idempotency | Architectural Phase 5 work |
| `EventResponse` PII DTO | Heavy lift — new sanitized DTO layer |
| RSVP DynamoDB atomicity | Requires conditional writes — tracked separately |

## Test plan
- [ ] `./gradlew :Application:compileJava :Application:test` — passes
- [ ] CI frontend lint — unquoted Inter + non-empty CSS block resolve ESLint/stylelint errors
- [ ] Manual: `PUT /campaigns/{id}` with mismatched body ID returns 400
- [ ] Manual: `PUT /users/{id}` — URL id always wins
- [ ] Manual: RSVP endpoint — JWT subject overrides request `volunteerId`
- [ ] Manual: Create event with capacity 0 → 400
- [ ] Manual: Update event shrinking capacity below confirmed count → 409

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Global 10-second request timeout for improved reliability.
  * Enhanced authentication token handling with improved cross-tab synchronization and automatic logout redirect.

* **Bug Fixes**
  * Fixed RSVP functionality to prevent unauthorized volunteer ID override.
  * Improved campaign and event update validation for data consistency.

* **Improvements**
  * Added event capacity validation to prevent overselling.
  * Enhanced login redirect logic to preserve requested page after authentication.
  * Improved error messaging for authentication failures.
  * Enhanced accessibility for event status indicators.
  * Optimized dashboard layout for full-width display.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/staceySpears/generositywell-fundraising-platform/pull/19)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->