### PR TITLE
fix: 7 CodeRabbit findings from PRs #21–22 (resolved in GitHub but not in code)

### DIFF
--- a/Application/src/main/java/com/kenzie/appserver/controller/UserController.java
+++ b/Application/src/main/java/com/kenzie/appserver/controller/UserController.java
@@ -6,8 +6,11 @@ import com.kenzie.appserver.service.FundraisingEventService;
 import com.kenzie.appserver.service.UserService;
 import com.kenzie.appserver.controller.model.DonationSummaryResponse;
 import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
 
@@ -112,26 +115,44 @@ public class UserController {
     }
 
     /**
-     * {@code GET /users/{id}/donations} — returns the user's giving history.
+     * {@code GET /users/{id}/donations} — returns the authenticated user's giving history.
+     * Callers may only retrieve their own history; a different ID returns 403.
      * One entry per campaign the user has donated to, sorted newest-first.
      *
-     * @param id the user ID
+     * @param id             the user ID (must match the JWT subject)
+     * @param authentication the authenticated principal
      * @return 200 with the list (may be empty)
+     * @throws ResponseStatusException 403 if the caller requests another user's history
      */
     @GetMapping("/{id}/donations")
-    public ResponseEntity<List<DonationSummaryResponse>> getDonationsByUser(@PathVariable("id") String id) {
+    public ResponseEntity<List<DonationSummaryResponse>> getDonationsByUser(
+            @PathVariable("id") String id,
+            Authentication authentication) {
+        if (!id.equals(authentication.getName())) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN,
+                    "You may only view your own donation history");
+        }
         return ResponseEntity.ok(campaignService.getDonationsByUser(id));
     }
 
     /**
-     * {@code GET /users/{id}/rsvps} — returns all events the user has RSVPed to.
+     * {@code GET /users/{id}/rsvps} — returns the authenticated user's RSVP history.
+     * Callers may only retrieve their own RSVPs; a different ID returns 403.
      * Excludes CANCELLED RSVPs. Sorted by event date ascending.
      *
-     * @param id the user ID
+     * @param id             the user ID (must match the JWT subject)
+     * @param authentication the authenticated principal
      * @return 200 with the list (may be empty)
+     * @throws ResponseStatusException 403 if the caller requests another user's RSVPs
      */
     @GetMapping("/{id}/rsvps")
-    public ResponseEntity<List<EventResponse>> getRsvpsByUser(@PathVariable("id") String id) {
+    public ResponseEntity<List<EventResponse>> getRsvpsByUser(
+            @PathVariable("id") String id,
+            Authentication authentication) {
+        if (!id.equals(authentication.getName())) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN,
+                    "You may only view your own RSVP history");
+        }
         return ResponseEntity.ok(eventService.getRsvpsByUser(id));
     }
 

--- a/Application/src/main/java/com/kenzie/appserver/repositories/model/SupporterTypeConverter.java
+++ b/Application/src/main/java/com/kenzie/appserver/repositories/model/SupporterTypeConverter.java
@@ -64,6 +64,9 @@ public class SupporterTypeConverter implements AttributeConverter<List<Supporter
      */
     @Override
     public List<Supporter> transformTo(AttributeValue input) {
+        if (input == null || Boolean.TRUE.equals(input.nul()) || input.l() == null) {
+            return new java.util.ArrayList<>();
+        }
         return input.l().stream().map(av -> {
             String raw = av.s();
             Supporter supporter = new Supporter();

--- a/Application/src/main/java/com/kenzie/appserver/security/SecurityConfig.java
+++ b/Application/src/main/java/com/kenzie/appserver/security/SecurityConfig.java
@@ -44,6 +44,9 @@ public class SecurityConfig {
                         // public read access to campaigns, events, and user profiles
                         .requestMatchers(HttpMethod.GET, "/campaigns/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/events/**").permitAll()
+                        // giving history and RSVP history are self-only — must come before the broad users permit
+                        .requestMatchers(HttpMethod.GET, "/users/*/donations").authenticated()
+                        .requestMatchers(HttpMethod.GET, "/users/*/rsvps").authenticated()
                         .requestMatchers(HttpMethod.GET, "/users/**").permitAll()
                         // donations are public so supporters don't need an account (Stripe handles identity)
                         .requestMatchers(HttpMethod.POST, "/campaigns/*/donate").permitAll()

--- a/Application/src/main/java/com/kenzie/appserver/service/CampaignService.java
+++ b/Application/src/main/java/com/kenzie/appserver/service/CampaignService.java
@@ -340,6 +340,13 @@ public class CampaignService {
         }
         return campaignDao.findByUserId(userId).stream()
                 .map(this::recordToResponse)
+                .sorted((a, b) -> {
+                    // Deadline descending — most recent first, nulls last
+                    if (a.getDeadline() == null && b.getDeadline() == null) return 0;
+                    if (a.getDeadline() == null) return 1;
+                    if (b.getDeadline() == null) return -1;
+                    return b.getDeadline().compareTo(a.getDeadline());
+                })
                 .toList();
     }
 

--- a/Application/src/main/java/com/kenzie/appserver/service/FundraisingEventService.java
+++ b/Application/src/main/java/com/kenzie/appserver/service/FundraisingEventService.java
@@ -139,7 +139,18 @@ public class FundraisingEventService {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Volunteer ID cannot be empty");
         }
         return eventDao.findByVolunteerId(volunteerId).stream()
-                .map(this::recordToResponse)
+                .map(record -> {
+                    EventResponse response = recordToResponse(record);
+                    // Strip all volunteer entries except the caller's own to avoid
+                    // exposing other attendees' names and emails.
+                    if (response.getVolunteers() != null) {
+                        response.setVolunteers(
+                                response.getVolunteers().stream()
+                                        .filter(v -> volunteerId.equals(v.getId()))
+                                        .collect(java.util.stream.Collectors.toList()));
+                    }
+                    return response;
+                })
                 .sorted((a, b) -> {
                     if (a.getEventDate() == null && b.getEventDate() == null) return 0;
                     if (a.getEventDate() == null) return 1;

--- a/Frontend/src/pages/DashboardPage/DashboardPage.jsx
+++ b/Frontend/src/pages/DashboardPage/DashboardPage.jsx
@@ -27,7 +27,8 @@ const formatDollars = (cents) =>
   new Intl.NumberFormat('en-US', {
     style: 'currency',
     currency: 'USD',
-    maximumFractionDigits: 0,
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 2,
   }).format((cents ?? 0) / 100);
 
 const RSVP_LABEL = { CONFIRMED: '✓ Confirmed', WAITLISTED: '⏳ Waitlisted' };
@@ -44,25 +45,41 @@ export default function DashboardPage() {
     enabled: !!userId,
   });
 
-  const { data: campaigns = [], isLoading: campaignsLoading } = useQuery({
+  const {
+    data: campaigns = [],
+    isLoading: campaignsLoading,
+    isError: campaignsError,
+  } = useQuery({
     queryKey: ['users', userId, 'campaigns'],
     queryFn: () => getUserCampaigns(userId),
     enabled: !!userId,
   });
 
-  const { data: events = [], isLoading: eventsLoading } = useQuery({
+  const {
+    data: events = [],
+    isLoading: eventsLoading,
+    isError: eventsError,
+  } = useQuery({
     queryKey: ['users', userId, 'events'],
     queryFn: () => getUserEvents(userId),
     enabled: !!userId,
   });
 
-  const { data: donations = [], isLoading: donationsLoading } = useQuery({
+  const {
+    data: donations = [],
+    isLoading: donationsLoading,
+    isError: donationsError,
+  } = useQuery({
     queryKey: ['users', userId, 'donations'],
     queryFn: () => getUserDonations(userId),
     enabled: !!userId,
   });
 
-  const { data: rsvps = [], isLoading: rsvpsLoading } = useQuery({
+  const {
+    data: rsvps = [],
+    isLoading: rsvpsLoading,
+    isError: rsvpsError,
+  } = useQuery({
     queryKey: ['users', userId, 'rsvps'],
     queryFn: () => getUserRsvps(userId),
     enabled: !!userId,
@@ -73,7 +90,7 @@ export default function DashboardPage() {
     register,
     handleSubmit,
     reset,
-    formState: { errors, isSubmitting },
+    formState: { errors },
   } = useForm({
     resolver: zodResolver(profileEditSchema),
     values: user ? { name: user.name, email: user.email } : undefined,
@@ -155,8 +172,12 @@ export default function DashboardPage() {
               )}
 
               <div className={styles.editActions}>
-                <button type="submit" className={styles.saveBtn} disabled={isSubmitting}>
-                  {isSubmitting ? 'Saving…' : 'Save'}
+                <button
+                  type="submit"
+                  className={styles.saveBtn}
+                  disabled={profileMutation.isPending}
+                >
+                  {profileMutation.isPending ? 'Saving…' : 'Save'}
                 </button>
                 <button type="button" className={styles.cancelBtn} onClick={cancelEdit}>
                   Cancel
@@ -180,6 +201,8 @@ export default function DashboardPage() {
           <h2 className={styles.cardTitle}>My campaigns</h2>
           {campaignsLoading ? (
             <p className={styles.placeholder}>Loading…</p>
+          ) : campaignsError ? (
+            <p className={styles.cardError}>Could not load campaigns. Try refreshing.</p>
           ) : campaigns.length === 0 ? (
             <p className={styles.placeholder}>
               You haven&apos;t created any campaigns yet.{' '}
@@ -207,6 +230,8 @@ export default function DashboardPage() {
           <h2 className={styles.cardTitle}>My events</h2>
           {eventsLoading ? (
             <p className={styles.placeholder}>Loading…</p>
+          ) : eventsError ? (
+            <p className={styles.cardError}>Could not load events. Try refreshing.</p>
           ) : events.length === 0 ? (
             <p className={styles.placeholder}>
               You haven&apos;t organized any events yet.{' '}
@@ -232,6 +257,8 @@ export default function DashboardPage() {
           <h2 className={styles.cardTitle}>My RSVPs</h2>
           {rsvpsLoading ? (
             <p className={styles.placeholder}>Loading…</p>
+          ) : rsvpsError ? (
+            <p className={styles.cardError}>Could not load RSVPs. Try refreshing.</p>
           ) : rsvps.length === 0 ? (
             <p className={styles.placeholder}>
               No upcoming RSVPs. <Link to="/events">Browse volunteer events</Link>.
@@ -259,6 +286,8 @@ export default function DashboardPage() {
           <h2 className={styles.cardTitle}>Giving history</h2>
           {donationsLoading ? (
             <p className={styles.placeholder}>Loading…</p>
+          ) : donationsError ? (
+            <p className={styles.cardError}>Could not load giving history. Try refreshing.</p>
           ) : donations.length === 0 ? (
             <p className={styles.placeholder}>
               Your donations will appear here after you contribute to a campaign.

--- a/Frontend/src/pages/DashboardPage/DashboardPage.module.css
+++ b/Frontend/src/pages/DashboardPage/DashboardPage.module.css
@@ -56,6 +56,10 @@
   color: var(--color-text-muted);
   line-height: 1.6;
 }
+.cardError {
+  font-size: 0.875rem;
+  color: var(--color-error);
+}
 .comingSoon {
   border-style: dashed;
 }


### PR DESCRIPTION
## Summary

These threads were all marked "Resolved" in GitHub but the underlying code was never changed. This PR actually fixes them.

## Issues fixed

| # | Severity | File | Finding |
|---|----------|------|---------|
| 1 | 🟠 Medium | `CampaignService` | `getCampaignsByUser` Javadoc promised deadline-descending sort; implementation returned unsorted DAO order |
| 2 | 🔴 Critical | `SupporterTypeConverter` | `transformTo()` called `input.l()` with no null/NUL guard — NPE on legacy or null-stored records |
| 3 | 🔴 Critical | `SecurityConfig` | `GET /users/**` was permit-all, making `/donations` and `/rsvps` publicly accessible without a JWT |
| 4 | 🔴 Critical | `UserController` | `/users/{id}/donations` and `/users/{id}/rsvps` had no ownership check — any authenticated user could read any user's private history |
| 5 | 🔴 Critical | `FundraisingEventService` | `getRsvpsByUser` returned full `volunteers` list, exposing all attendees' names and emails |
| 6 | 🟠 Medium | `DashboardPage.jsx` | Profile Save used RHF `isSubmitting` (resets immediately after fire-and-forget `mutate()`) instead of `profileMutation.isPending` |
| 7 | 🟠 Medium | `DashboardPage.jsx` | Card query errors silently collapsed to empty-state UI; `formatDollars` rounded non-whole-cent amounts to nearest dollar |

## What changed

- **`CampaignService`** — add deadline-descending sort to `getCampaignsByUser`
- **`SupporterTypeConverter`** — `if (input == null || nul() || l() == null) return emptyList()`
- **`SecurityConfig`** — add `.authenticated()` rules for `/users/*/donations` and `/users/*/rsvps` before the broad permit-all
- **`UserController`** — inject `Authentication` into both endpoints; throw 403 if `id != authentication.getName()`
- **`FundraisingEventService`** — filter `response.getVolunteers()` to only the caller's own entry before returning
- **`DashboardPage.jsx`** — `disabled={profileMutation.isPending}`, `{profileMutation.isPending ? 'Saving…' : 'Save'}`, remove unused `isSubmitting`; add `isError` → `.cardError` branch to all four data cards; `formatDollars` now uses `min:0/max:2` fraction digits

## Test plan

- [ ] `GET /users/{id}/donations` without JWT → 401
- [ ] `GET /users/{id}/donations` with JWT for a different user → 403
- [ ] `GET /users/{id}/donations` with matching JWT → 200
- [ ] Donate to a campaign (logged in) → giving history shows correct dollar amount for fractional-cent edge cases
- [ ] Profile Save button stays disabled for the full async duration (no double-submit)
- [ ] Simulate a failed card query (e.g., kill API) → dashboard card shows "Could not load…" instead of empty state
- [ ] Build & Unit Tests ✅ · Frontend Lint & Format ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed potential null pointer exceptions in data deserialization
  * Enhanced error handling and display across dashboard sections
  * Corrected currency formatting display

* **New Features**
  * Secured user donation and RSVP history endpoints with authentication verification
  * Added deadline-based sorting for user campaigns
  * Improved RSVP display to show only the authenticated user's volunteer entry

* **Style**
  * Added error message styling

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/staceySpears/generositywell-fundraising-platform/pull/23)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->