### PR TITLE
chore: fix 4 markdown linting nitpicks in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,7 @@ modernized and extended into a fundraising domain.
 ---
 
 ## Current Stack (fully built — do not re-implement)
+
 | Layer | Technology |
 |---|---|
 | REST API | Spring Boot 3.2.5 / Java 21 |
@@ -35,7 +36,7 @@ modernized and extended into a fundraising domain.
 ---
 
 ## Repository Structure
-```
+```text
 generositywell-fundraising-platform/
 ├── Application/src/main/java/com/kenzie/appserver/
 │   ├── config/           — CacheStore (Caffeine), DynamoDbConfig, AsyncConfig, StripeConfig
@@ -125,6 +126,7 @@ generositywell-fundraising-platform/
 ---
 
 ## Frontend Pages (all built)
+
 | Page | Route | Notes |
 |---|---|---|
 | Landing | `/` | Public marketing page |
@@ -179,7 +181,7 @@ Or from inside Claude Code: `/cr-fix`
 ---
 
 ## Coding Standards
-- **Never store money as `double`/`float`** — always `Long` (cents)
+- **Never store money as `double`/`float`** — see *Key Architectural Decisions* above
 - **Never compare Strings with `==`** — use `.equals()` or `.isBlank()`
 - **Never hardcode secrets** — use `@Value("${property}")` + env vars
 - **Null-safe ownership checks** — `Objects.equals(requestingUserId, record.getUser().getId())`


### PR DESCRIPTION
## Summary

- Blank line before table under "Current Stack" (markdown lint MD055)
- Blank line before table under "Frontend Pages" (markdown lint MD055)
- ` ```text ` language tag on the repo-structure code fence (MD040)
- Rephrase duplicate wording in Coding Standards bullet

These were CodeRabbit's nitpicks from PR #24 — fixed after the PR was already merged, so they're landing as a follow-up.

## Test plan

- [ ] Verify CLAUDE.md renders cleanly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal development documentation with minor formatting improvements and clarifications to coding standards references.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/staceySpears/generositywell-fundraising-platform/pull/25)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->