### PR TITLE
feat: Stripe payment UI — two-step donate flow with PaymentElement

### DIFF
--- a/.claude/commands/cr-fix.md
+++ b/.claude/commands/cr-fix.md
@@ -1,0 +1,32 @@
+# /cr-fix
+
+Fetch the **latest** CodeRabbit review for the current branch's open PR and apply all unresolved findings.
+
+Use this after CodeRabbit's green check appears on GitHub. Running it too early returns stale data because the GitHub API is pull-only — CodeRabbit's review won't exist yet.
+
+## What this does
+
+1. Resolves the open PR number for the current branch
+2. Checks whether CodeRabbit is still processing (exits early with a message if so)
+3. Fetches every unresolved, non-outdated CodeRabbit review thread via GraphQL
+4. For each thread: reads the relevant code, assesses validity, proposes a fix
+5. Shows each proposed fix and asks for approval before applying
+6. Commits all approved fixes in a single `fix: apply CodeRabbit auto-fixes` commit
+
+## When to run
+
+```
+git push
+# wait ~90 seconds for the CodeRabbit status check to go green on GitHub
+/cr-fix
+```
+
+Or from the terminal without opening Claude Code first:
+
+```bash
+git push && ./cr-fix.sh
+```
+
+## Invoke the autofix skill
+
+$ARGUMENTS

--- a/.gitignore
+++ b/.gitignore
@@ -31,5 +31,7 @@ lambda-service-development.yml
 # macOS
 .DS_Store
 
-# Claude Code worktrees and session data
+# Claude Code worktrees and session data (local-only)
 .claude/
+# …except shared slash commands, which belong in source control
+!.claude/commands/

--- a/Application/src/main/java/com/kenzie/appserver/controller/CampaignController.java
+++ b/Application/src/main/java/com/kenzie/appserver/controller/CampaignController.java
@@ -83,18 +83,22 @@ public class CampaignController {
 
     /**
      * {@code POST /campaigns/{campaignId}/payment-intent} — creates a Stripe PaymentIntent.
-     * The campaign ID is embedded in the PaymentIntent metadata so the webhook can record
-     * the donation after payment succeeds. Requires a valid JWT.
+     * Both campaign ID and authenticated donor ID are embedded in the PaymentIntent metadata
+     * so the webhook can record the donation—and attribute it to the donor—after payment
+     * succeeds. Requires a valid JWT.
      *
-     * @param campaignId the target campaign
-     * @param request    the payment amount
+     * @param campaignId     the target campaign
+     * @param request        the payment amount
+     * @param authentication the authenticated principal (JWT subject used as donor ID)
      * @return 200 with the client secret for front-end confirmation
      */
     @PostMapping("/{campaignId}/payment-intent")
     public ResponseEntity<PaymentIntentResponse> createPaymentIntent(
             @PathVariable("campaignId") String campaignId,
-            @Valid @RequestBody PaymentIntentRequest request) {
-        PaymentIntentResponse response = stripeService.createPaymentIntent(campaignId, request.getAmount());
+            @Valid @RequestBody PaymentIntentRequest request,
+            Authentication authentication) {
+        String donorId = authentication != null ? authentication.getName() : null;
+        PaymentIntentResponse response = stripeService.createPaymentIntent(campaignId, request.getAmount(), donorId);
         return ResponseEntity.ok(response);
     }
 

--- a/Application/src/main/java/com/kenzie/appserver/controller/StripeWebhookController.java
+++ b/Application/src/main/java/com/kenzie/appserver/controller/StripeWebhookController.java
@@ -65,13 +65,15 @@ public class StripeWebhookController {
             Optional<StripeObject> stripeObject = event.getDataObjectDeserializer().getObject();
             if (stripeObject.isPresent() && stripeObject.get() instanceof PaymentIntent intent) {
                 String campaignId = intent.getMetadata().get("campaignId");
+                // donorId is present when the payment was initiated by an authenticated user;
+                // null for anonymous payments (e.g. shared payment links with no login)
+                String donorId = intent.getMetadata().get("donorId");
                 long amount = intent.getAmount();
 
                 if (campaignId != null) {
                     try {
-                        // donorId is null for webhook path — no authenticated user context
-                        campaignService.addDonation(campaignId, amount, null);
-                        log.info("Donation recorded: campaign={} amount={}", campaignId, amount);
+                        campaignService.addDonation(campaignId, amount, donorId);
+                        log.info("Donation recorded: campaign={} amount={} donor={}", campaignId, amount, donorId);
                     } catch (Exception e) {
                         // Log but return 200 — Stripe retries on non-2xx, and the payment already succeeded
                         log.error("Failed to record donation for campaign {}: {}", campaignId, e.getMessage());

--- a/Application/src/main/java/com/kenzie/appserver/controller/StripeWebhookController.java
+++ b/Application/src/main/java/com/kenzie/appserver/controller/StripeWebhookController.java
@@ -73,7 +73,7 @@ public class StripeWebhookController {
                 if (campaignId != null) {
                     try {
                         campaignService.addDonation(campaignId, amount, donorId);
-                        log.info("Donation recorded: campaign={} amount={} donor={}", campaignId, amount, donorId);
+                        log.info("Donation recorded: campaign={} amount={} authenticated={}", campaignId, amount, donorId != null);
                     } catch (Exception e) {
                         // Log but return 200 — Stripe retries on non-2xx, and the payment already succeeded
                         log.error("Failed to record donation for campaign {}: {}", campaignId, e.getMessage());

--- a/Application/src/main/java/com/kenzie/appserver/service/StripeService.java
+++ b/Application/src/main/java/com/kenzie/appserver/service/StripeService.java
@@ -14,24 +14,29 @@ public class StripeService {
 
     /**
      * Creates a Stripe PaymentIntent for the given campaign and amount.
-     * The campaign ID is stored in the PaymentIntent metadata so the webhook
-     * handler can record the donation after payment succeeds.
+     * Both {@code campaignId} and {@code donorId} (when present) are stored in the
+     * PaymentIntent metadata so the webhook handler can record the donation—and
+     * attribute it to the authenticated donor—after payment succeeds.
      * Throws 502 if the Stripe API returns an error.
      *
-     * @param campaignId   the local campaign ID to attach to the payment intent metadata
+     * @param campaignId    the local campaign ID to attach to the payment intent metadata
      * @param amountInCents the amount to charge in the smallest currency unit (cents)
+     * @param donorId       the authenticated user ID, or {@code null} for anonymous payments
      * @return the client secret, payment intent ID, and amount
      */
-    public PaymentIntentResponse createPaymentIntent(String campaignId, Long amountInCents) {
+    public PaymentIntentResponse createPaymentIntent(String campaignId, Long amountInCents, String donorId) {
         try {
-            PaymentIntentCreateParams params = PaymentIntentCreateParams.builder()
+            PaymentIntentCreateParams.Builder builder = PaymentIntentCreateParams.builder()
                     .setAmount(amountInCents)
                     .setCurrency("usd")
                     .putMetadata("campaignId", campaignId)
-                    .addPaymentMethodType("card")
-                    .build();
+                    .addPaymentMethodType("card");
 
-            PaymentIntent intent = PaymentIntent.create(params);
+            if (donorId != null) {
+                builder.putMetadata("donorId", donorId);
+            }
+
+            PaymentIntent intent = PaymentIntent.create(builder.build());
             return new PaymentIntentResponse(intent.getClientSecret(), intent.getId(), amountInCents);
 
         } catch (StripeException e) {

--- a/Frontend/.env.example
+++ b/Frontend/.env.example
@@ -5,3 +5,7 @@
 # Leave empty in development — the Vite proxy (/api/* → localhost:5001) handles it.
 # Set to your production API URL (e.g. https://api.generositywell.com) for production builds.
 VITE_API_BASE_URL=
+
+# Stripe publishable key (safe to expose in the browser — starts with pk_test_ or pk_live_).
+# Find it at https://dashboard.stripe.com/apikeys
+VITE_STRIPE_PUBLISHABLE_KEY=

--- a/Frontend/package-lock.json
+++ b/Frontend/package-lock.json
@@ -12,6 +12,8 @@
         "@radix-ui/react-dialog": "^1.1.4",
         "@radix-ui/react-label": "^2.1.2",
         "@radix-ui/react-toast": "^1.2.4",
+        "@stripe/react-stripe-js": "^6.3.0",
+        "@stripe/stripe-js": "^9.4.0",
         "@tanstack/react-query": "^5.62.0",
         "@tanstack/react-query-devtools": "^5.62.0",
         "axios": "^1.7.9",
@@ -1884,6 +1886,29 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@stripe/react-stripe-js": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@stripe/react-stripe-js/-/react-stripe-js-6.3.0.tgz",
+      "integrity": "sha512-N1FTRNCMKySElDz1lAsf/m6Oy5vcl6LRVXcW29t0Y3U3HYOAqCBlk6nuDsR2x7SAuaXkVCjnpCqrNbA/7l74jg==",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "^15.7.2"
+      },
+      "peerDependencies": {
+        "@stripe/stripe-js": ">=9.3.1 <10.0.0",
+        "react": ">=16.8.0 <20.0.0",
+        "react-dom": ">=16.8.0 <20.0.0"
+      }
+    },
+    "node_modules/@stripe/stripe-js": {
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/@stripe/stripe-js/-/stripe-js-9.4.0.tgz",
+      "integrity": "sha512-zXG86DnoLU5nH2U18tX5ApTE3IAm+txoiPm4YFyEtRS0K5y7ZDH9M8e1Le/cZyI6wvW3BkJn2daZe2FqZOrSSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.16"
+      }
     },
     "node_modules/@tanstack/query-core": {
       "version": "5.100.9",
@@ -4299,7 +4324,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -4600,7 +4624,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
@@ -4681,7 +4704,6 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/react-refresh": {

--- a/Frontend/package.json
+++ b/Frontend/package.json
@@ -17,6 +17,8 @@
     "@radix-ui/react-dialog": "^1.1.4",
     "@radix-ui/react-label": "^2.1.2",
     "@radix-ui/react-toast": "^1.2.4",
+    "@stripe/react-stripe-js": "^6.3.0",
+    "@stripe/stripe-js": "^9.4.0",
     "@tanstack/react-query": "^5.62.0",
     "@tanstack/react-query-devtools": "^5.62.0",
     "axios": "^1.7.9",

--- a/Frontend/src/api/campaignApi.js
+++ b/Frontend/src/api/campaignApi.js
@@ -31,6 +31,22 @@ export const updateCampaign = async (campaignId, payload) => {
 };
 
 /**
+ * Creates a Stripe PaymentIntent for the given campaign and amount.
+ * Returns { clientSecret, paymentIntentId, amount }.
+ * Requires a valid JWT (Authorization header set by the Axios interceptor).
+ *
+ * @param {string} campaignId
+ * @param {number} amountInCents
+ * @returns {Promise<{ clientSecret: string, paymentIntentId: string, amount: number }>}
+ */
+export const createPaymentIntent = async (campaignId, amountInCents) => {
+  const { data } = await client.post(`/campaigns/${campaignId}/payment-intent`, {
+    amount: amountInCents,
+  });
+  return data;
+};
+
+/**
  * @param {string} campaignId
  * @param {number} amountInCents
  */

--- a/Frontend/src/lib/stripe.js
+++ b/Frontend/src/lib/stripe.js
@@ -1,0 +1,9 @@
+import { loadStripe } from '@stripe/stripe-js';
+
+/**
+ * Singleton Stripe.js promise.
+ * loadStripe() must be called outside of a component render to avoid
+ * re-creating the Stripe object on every render.
+ * Set VITE_STRIPE_PUBLISHABLE_KEY in .env.local (see .env.example).
+ */
+export const stripePromise = loadStripe(import.meta.env.VITE_STRIPE_PUBLISHABLE_KEY ?? '');

--- a/Frontend/src/pages/CampaignDetailPage/CampaignDetailPage.jsx
+++ b/Frontend/src/pages/CampaignDetailPage/CampaignDetailPage.jsx
@@ -1,12 +1,15 @@
-import { useRef } from 'react';
+import { useRef, useState } from 'react';
 import { useParams } from 'react-router-dom';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useQuery, useMutation } from '@tanstack/react-query';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import * as Label from '@radix-ui/react-label';
 import { QRCodeSVG } from 'qrcode.react';
-import { getCampaignById, donate } from '../../api/campaignApi.js';
+import { Elements } from '@stripe/react-stripe-js';
+import { getCampaignById, createPaymentIntent } from '../../api/campaignApi.js';
+import { stripePromise } from '../../lib/stripe.js';
 import { donationSchema } from '../../schemas/campaign.js';
+import StripePaymentForm from './StripePaymentForm.jsx';
 import styles from './CampaignDetailPage.module.css';
 
 /** Formats an ISO date string (e.g. "2026-05-01") as "May 1, 2026". */
@@ -44,10 +47,20 @@ function downloadQR(qrRef, campaignName) {
   URL.revokeObjectURL(url);
 }
 
+/**
+ * Donation flow states:
+ *   'amount'  — user enters dollar amount
+ *   'card'    — Stripe PaymentElement shown for card entry
+ *   'success' — payment confirmed; webhook records the donation asynchronously
+ */
+
 export default function CampaignDetailPage() {
   const { id } = useParams();
-  const queryClient = useQueryClient();
   const qrRef = useRef(null);
+
+  // Donation flow state
+  const [paymentStep, setPaymentStep] = useState('amount');
+  const [pendingPayment, setPendingPayment] = useState(null); // { clientSecret, amountInCents }
 
   const {
     data: campaign,
@@ -65,15 +78,29 @@ export default function CampaignDetailPage() {
     formState: { errors },
   } = useForm({ resolver: zodResolver(donationSchema) });
 
-  const mutation = useMutation({
-    mutationFn: ({ dollars }) => donate(id, Math.round(dollars * 100)),
-    onSuccess: () => {
-      // Invalidate both the detail and the list so both reflect the new total.
-      queryClient.invalidateQueries({ queryKey: ['campaigns', id] });
-      queryClient.invalidateQueries({ queryKey: ['campaigns'] });
+  // Step 1: create a PaymentIntent on the backend, then advance to the card step
+  const createIntentMutation = useMutation({
+    mutationFn: ({ dollars }) => createPaymentIntent(id, Math.round(dollars * 100)),
+    onSuccess: (data, variables) => {
+      setPendingPayment({
+        clientSecret: data.clientSecret,
+        amountInCents: Math.round(variables.dollars * 100),
+      });
+      setPaymentStep('card');
       reset();
     },
   });
+
+  const handlePaymentSuccess = () => {
+    setPaymentStep('success');
+    setPendingPayment(null);
+  };
+
+  const handleBackToAmount = () => {
+    setPaymentStep('amount');
+    setPendingPayment(null);
+    createIntentMutation.reset();
+  };
 
   if (isLoading) return <p className={styles.state}>Loading…</p>;
   if (isError) return <p className={styles.stateError}>Campaign not found.</p>;
@@ -115,47 +142,83 @@ export default function CampaignDetailPage() {
         </div>
 
         {!isClosed && (
-          <form
-            onSubmit={handleSubmit((values) => mutation.mutate(values))}
-            noValidate
-            className={styles.donateForm}
-          >
-            <h2 className={styles.donateTitle}>Make a donation</h2>
-            <div className={styles.field}>
-              <Label.Root htmlFor="dollars" className={styles.label}>
-                Amount (USD)
-              </Label.Root>
-              <div className={styles.inputWrapper}>
-                <span className={styles.currency}>$</span>
-                <input
-                  id="dollars"
-                  type="number"
-                  min="1"
-                  step="1"
-                  placeholder="25"
-                  className={`${styles.input} ${errors.dollars ? styles.inputError : ''}`}
-                  {...register('dollars', {
-                    valueAsNumber: true,
-                    onChange: () => mutation.isSuccess && mutation.reset(),
-                  })}
+          <>
+            {/* ── Step 1: amount entry ──────────────────── */}
+            {paymentStep === 'amount' && (
+              <form
+                onSubmit={handleSubmit((values) => createIntentMutation.mutate(values))}
+                noValidate
+                className={styles.donateForm}
+              >
+                <h2 className={styles.donateTitle}>Make a donation</h2>
+                <div className={styles.field}>
+                  <Label.Root htmlFor="dollars" className={styles.label}>
+                    Amount (USD)
+                  </Label.Root>
+                  <div className={styles.inputWrapper}>
+                    <span className={styles.currency}>$</span>
+                    <input
+                      id="dollars"
+                      type="number"
+                      min="1"
+                      step="1"
+                      placeholder="25"
+                      className={`${styles.input} ${errors.dollars ? styles.inputError : ''}`}
+                      {...register('dollars', { valueAsNumber: true })}
+                    />
+                  </div>
+                  {errors.dollars && <span className={styles.error}>{errors.dollars.message}</span>}
+                </div>
+
+                {createIntentMutation.isError && (
+                  <p className={styles.serverError}>
+                    {createIntentMutation.error?.response?.data?.message ??
+                      'Could not start payment. Please try again.'}
+                  </p>
+                )}
+
+                <button
+                  type="submit"
+                  className={styles.donateBtn}
+                  disabled={createIntentMutation.isPending}
+                >
+                  {createIntentMutation.isPending ? 'Preparing…' : 'Continue to payment →'}
+                </button>
+              </form>
+            )}
+
+            {/* ── Step 2: card entry via Stripe ─────────── */}
+            {paymentStep === 'card' && pendingPayment && (
+              <Elements
+                stripe={stripePromise}
+                options={{ clientSecret: pendingPayment.clientSecret }}
+              >
+                <StripePaymentForm
+                  amountInCents={pendingPayment.amountInCents}
+                  onSuccess={handlePaymentSuccess}
+                  onBack={handleBackToAmount}
                 />
+              </Elements>
+            )}
+
+            {/* ── Step 3: success ───────────────────────── */}
+            {paymentStep === 'success' && (
+              <div className={styles.successCard}>
+                <p className={styles.successHeading}>🎉 Thank you!</p>
+                <p className={styles.successNote}>
+                  Your payment is confirmed. The campaign total will update shortly as your donation
+                  is processed.
+                </p>
+                <button
+                  type="button"
+                  className={styles.backBtn}
+                  onClick={() => setPaymentStep('amount')}
+                >
+                  Donate again
+                </button>
               </div>
-              {errors.dollars && <span className={styles.error}>{errors.dollars.message}</span>}
-            </div>
-
-            {mutation.isError && (
-              <p className={styles.serverError}>
-                {mutation.error?.response?.data?.message ?? 'Donation failed. Please try again.'}
-              </p>
             )}
-            {mutation.isSuccess && (
-              <p className={styles.serverSuccess}>Thank you for your donation!</p>
-            )}
-
-            <button type="submit" className={styles.donateBtn} disabled={mutation.isPending}>
-              {mutation.isPending ? 'Processing…' : 'Donate'}
-            </button>
-          </form>
+          </>
         )}
 
         {isClosed && (

--- a/Frontend/src/pages/CampaignDetailPage/CampaignDetailPage.module.css
+++ b/Frontend/src/pages/CampaignDetailPage/CampaignDetailPage.module.css
@@ -232,6 +232,64 @@
   text-align: center;
 }
 
+/* ── Stripe card element wrapper ──────────────────────────── */
+.stripeElement {
+  padding: 0.75rem;
+  background-color: var(--color-surface-alt);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+}
+
+/* ── Back / secondary button ─────────────────────────────── */
+.backBtn {
+  background: none;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: 0.625rem 0.75rem;
+  font-size: 0.875rem;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  transition:
+    background-color 0.15s,
+    border-color 0.15s,
+    color 0.15s;
+}
+
+.backBtn:hover:not(:disabled) {
+  background-color: var(--color-surface-alt);
+  border-color: var(--color-primary);
+  color: var(--color-text);
+}
+
+.backBtn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* ── Payment success card ─────────────────────────────────── */
+.successCard {
+  background-color: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  text-align: center;
+}
+
+.successHeading {
+  font-size: 1.125rem;
+  font-weight: 700;
+  color: var(--color-success);
+}
+
+.successNote {
+  font-size: 0.875rem;
+  color: var(--color-text-muted);
+  line-height: 1.6;
+}
+
 /* ── QR code card ─────────────────────────────────────────── */
 .qrCard {
   background-color: var(--color-surface);

--- a/Frontend/src/pages/CampaignDetailPage/StripePaymentForm.jsx
+++ b/Frontend/src/pages/CampaignDetailPage/StripePaymentForm.jsx
@@ -1,0 +1,71 @@
+import { useState } from 'react';
+import { PaymentElement, useStripe, useElements } from '@stripe/react-stripe-js';
+import styles from './CampaignDetailPage.module.css';
+
+const formatDollars = (cents) =>
+  new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 2,
+  }).format((cents ?? 0) / 100);
+
+/**
+ * Card entry form rendered inside a Stripe <Elements> provider.
+ * Calls stripe.confirmPayment() with redirect:'if_required' so standard
+ * card payments complete in-place without a page redirect.
+ *
+ * @param {{ amountInCents: number, onSuccess: () => void, onBack: () => void }} props
+ */
+export default function StripePaymentForm({ amountInCents, onSuccess, onBack }) {
+  const stripe = useStripe();
+  const elements = useElements();
+  const [isProcessing, setIsProcessing] = useState(false);
+  const [errorMessage, setErrorMessage] = useState(null);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (!stripe || !elements) return;
+
+    setIsProcessing(true);
+    setErrorMessage(null);
+
+    const { error } = await stripe.confirmPayment({
+      elements,
+      confirmParams: {
+        // Required by Stripe even when redirect:'if_required' avoids an actual redirect
+        return_url: window.location.href,
+      },
+      redirect: 'if_required',
+    });
+
+    if (error) {
+      // card_error and validation_error messages are safe to show to the user
+      setErrorMessage(error.message ?? 'Payment failed. Please try again.');
+      setIsProcessing(false);
+    } else {
+      // Payment succeeded — the webhook will record the donation asynchronously
+      onSuccess();
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} noValidate className={styles.donateForm}>
+      <h2 className={styles.donateTitle}>Pay {formatDollars(amountInCents)}</h2>
+
+      <div className={styles.stripeElement}>
+        <PaymentElement />
+      </div>
+
+      {errorMessage && <p className={styles.serverError}>{errorMessage}</p>}
+
+      <button type="submit" className={styles.donateBtn} disabled={isProcessing || !stripe}>
+        {isProcessing ? 'Processing…' : `Donate ${formatDollars(amountInCents)}`}
+      </button>
+
+      <button type="button" className={styles.backBtn} onClick={onBack} disabled={isProcessing}>
+        ← Change amount
+      </button>
+    </form>
+  );
+}


### PR DESCRIPTION
## Summary

Replaces the previous direct `/donate` call with a full Stripe PaymentIntent flow on the Campaign Detail page.

**User experience:**
1. Enter donation amount → "Continue to payment →"
2. Stripe `<PaymentElement>` appears for card entry (handles card, Apple Pay, etc.)
3. `stripe.confirmPayment()` fires with `redirect: 'if_required'` (no page redirect for standard cards)
4. Success card shown — webhook records the donation asynchronously

**Backend changes:**
- `StripeService.createPaymentIntent` — adds optional `donorId` parameter embedded in PaymentIntent metadata
- `CampaignController` — extracts `donorId` from JWT auth principal, passes to `StripeService`
- `StripeWebhookController` — reads `donorId` from metadata, passes to `addDonation()` so authenticated Stripe donations now appear in giving history

**Frontend changes:**
- `@stripe/react-stripe-js` + `@stripe/stripe-js` installed
- `src/lib/stripe.js` — singleton `loadStripe()` (called once, outside renders)
- `campaignApi.js` — `createPaymentIntent(campaignId, amountInCents)` added
- `StripePaymentForm.jsx` — new component; uses `useStripe` + `useElements` hooks, `<PaymentElement>`, confirm + error handling
- `CampaignDetailPage` — three-state flow: `amount → card → success`; `<Elements>` provider wraps card step only (mounted after `clientSecret` is available)
- CSS — `.stripeElement`, `.backBtn`, `.successCard`, `.successHeading`, `.successNote`
- `.env.example` — documents `VITE_STRIPE_PUBLISHABLE_KEY`

## Setup required

Add to `Frontend/.env.local`:
```
VITE_STRIPE_PUBLISHABLE_KEY=pk_test_...
```
Get the key from https://dashboard.stripe.com/apikeys (use the test key for development).

For local webhook testing, use the [Stripe CLI](https://stripe.com/docs/stripe-cli):
```bash
stripe listen --forward-to localhost:5001/webhooks/stripe
```

## Test plan

- [ ] Enter amount, click "Continue to payment →" — Stripe card element appears
- [ ] Use Stripe test card `4242 4242 4242 4242` — payment succeeds, success card shown
- [ ] Use Stripe decline card `4000 0000 0000 0002` — error message shown, can retry
- [ ] Click "← Change amount" — returns to amount step
- [ ] Authenticated donation: check giving history on dashboard after webhook fires
- [ ] Anonymous donation (no JWT): webhook records donation with null donorId (no giving history entry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-step donation flow (amount → card → success) with Stripe-powered card payment UI
  * Frontend Stripe integration: loader, publishable key example, API call to create payment intents, and added Stripe libs

* **Bug Fixes**
  * Webhook and backend updates to attribute donations to donors via payment metadata and improved success logging

* **Documentation**
  * Environment example updated with Stripe publishable key guidance

* **Chores**
  * Add shared command doc and adjust ignore rules for command files

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/staceySpears/generositywell-fundraising-platform/pull/26)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->